### PR TITLE
[backend][ios] auto-update scheduler, bulk progress, duplicate scrape guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,46 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Long press on a ZStack overlay blocks `ScrollView`** — use `.simultaneousGesture(LongPressGesture(...).onEnded { })` instead of `.onLongPressGesture` so the scroll and long-press recognizers coexist.
 - `scrollTargetBehavior(.paging)` + `scrollPosition(id:)` on a horizontal `ScrollView` + `LazyHStack` is the preferred paged reader pattern (smoother than `TabView(.page)`).
 - Reading progress (`lastReadChapterNumber`, `progressPercent`, `lastReadAt`) is written in `ComicReaderView.loadPages()` each time a chapter is opened — not debounced for local SwiftData writes.
+
+## AI Agent Rules
+
+### Required scratchpad workflow
+
+All AI agents must keep reasoning notes in `scratchpad/*.md`.
+
+Rules:
+- Create or update a markdown file in `scratchpad/` for task-level thinking.
+- Scratchpad notes are for planning, intermediate reasoning, and working assumptions only.
+- Use the lowest-capability / lowest-cost model available when generating scratchpad notes.
+- Do not use an expensive frontier model for scratchpad drafting.
+- Do not place secrets, credentials, tokens, or sensitive user data in scratchpad files.
+
+Suggested naming:
+- `scratchpad/claude-YYYY-MM-DD-task-name.md`
+
+### General coding rules
+
+- Read files before changing them.
+- Prefer minimum viable edits.
+- Keep parsing, heuristics, and scoring out of page components when possible.
+- Extend config/feature/store modules before adding UI-only hacks.
+- Run `npm run build` after changes.
+- Run targeted Playwright coverage for analysis changes when practical.
+
+### Documentation rules
+
+Update docs when these change:
+- RuleSheets workflow
+- persistence behavior
+- logging/observability
+- benchmark commands
+- major routes or surface behavior
+- scratchpad process
+
+## Branch and Git Rules
+
+- The god branch is `release-1`. All feature and fix branches must be branched from `release-1` and merged back via PR.
+- Never push directly to `release-1`.
+- Use the assigned feature branch.
+- Do not force-push without explicit approval.
+- Do not commit `.env` files or secrets.

--- a/backend/app/api/v1/routes/progress.py
+++ b/backend/app/api/v1/routes/progress.py
@@ -1,11 +1,20 @@
 import uuid
-from fastapi import APIRouter, Depends, HTTPException, Path
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_db
 from app.schemas.progress import ComicProgressRequest, FanficProgressRequest, ProgressResponse
 from app.services import progress_service
 
 router = APIRouter(prefix="/progress", tags=["progress"])
+
+
+@router.get("", response_model=list[ProgressResponse])
+async def get_all_progress(
+    content_type: str = Query(..., pattern="^(comic|fanfic)$"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return all progress records for a content type. iOS calls this once on launch."""
+    return await progress_service.get_all_progress(db, content_type)
 
 
 @router.put("/comic/{story_id}", response_model=ProgressResponse)

--- a/backend/app/services/progress_service.py
+++ b/backend/app/services/progress_service.py
@@ -94,6 +94,22 @@ async def upsert_fanfic_progress(
     return _to_schema(progress)
 
 
+async def get_all_progress(
+    db: AsyncSession,
+    content_type: str,
+) -> list[ProgressResponse]:
+    """Return all progress records for a content type — lets iOS hydrate the library in one call."""
+    logger.info("get_all_progress called | content_type=%s", content_type)
+    result = await db.execute(
+        select(ReadingProgress).where(
+            ReadingProgress.content_type == content_type,
+        ).order_by(ReadingProgress.updated_at.desc())
+    )
+    rows = result.scalars().all()
+    logger.info("get_all_progress returning %d records | content_type=%s", len(rows), content_type)
+    return [_to_schema(p) for p in rows]
+
+
 async def get_progress(
     db: AsyncSession,
     content_type: str,

--- a/backend/app/services/scrape_service.py
+++ b/backend/app/services/scrape_service.py
@@ -99,6 +99,27 @@ async def initiate_scrape(db: AsyncSession, body: ScrapeRequest) -> ScrapeJobRes
             db.add(fanfic)
             logger.info("initiate_scrape new fanfic placeholder created | story_id=%s", story_id)
 
+    # If the story already exists, check for a complete/partial job — don't re-scrape
+    if existing:
+        result = await db.execute(
+            select(ScrapeJob)
+            .where(
+                ScrapeJob.story_id == story_id,
+                ScrapeJob.status.in_([JobStatus.COMPLETE, JobStatus.PARTIAL]),
+                ScrapeJob.deleted_at.is_(None),
+            )
+            .order_by(ScrapeJob.created_at.desc())
+            .limit(1)
+        )
+        completed_job = result.scalar_one_or_none()
+        if completed_job:
+            logger.info(
+                "initiate_scrape duplicate suppressed — story already scraped | "
+                "story_id=%s existing_job_id=%s status=%s",
+                story_id, completed_job.id, completed_job.status,
+            )
+            return _job_to_schema(completed_job)
+
     job = ScrapeJob(
         content_type=body.content_type,
         story_id=story_id,

--- a/backend/app/tasks/auto_update_task.py
+++ b/backend/app/tasks/auto_update_task.py
@@ -1,0 +1,120 @@
+import logging
+import uuid
+from arq.connections import ArqRedis
+from sqlalchemy import select, and_
+from sqlalchemy.orm import selectinload
+from app.db.database import AsyncSessionLocal
+from app.models.comic import Comic
+from app.models.fanfic import Fanfic
+from app.models.scrape import ScrapeJob
+from app.core.constants import JobStatus, JobType, SourceKey
+import redis.asyncio as aioredis
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Sources that have ongoing series with new chapters (nhentai is single galleries — skip it)
+SERIES_SOURCES = {SourceKey.TOONGOD, SourceKey.HENTAI20}
+
+
+async def auto_update_task(ctx):
+    """
+    ARQ cron: every 6 hours, queue delta jobs for all ongoing content
+    that has no active (queued/running) job.
+    - Fanfics: all with completion_status != 'complete'
+    - Comics: all from series sources (toongod, hentai20)
+    """
+    logger.info("auto_update_task started")
+    queued = 0
+    skipped_active = 0
+
+    async with AsyncSessionLocal() as db:
+        # Fetch all story IDs with an active job to avoid double-queueing
+        active_result = await db.execute(
+            select(ScrapeJob.story_id).where(
+                ScrapeJob.status.in_([JobStatus.QUEUED, JobStatus.RUNNING]),
+                ScrapeJob.deleted_at.is_(None),
+            )
+        )
+        active_story_ids: set[uuid.UUID] = {row[0] for row in active_result.all()}
+        logger.info("auto_update_task active jobs for story_ids=%d", len(active_story_ids))
+
+        # --- Ongoing fanfics ---
+        fanfic_result = await db.execute(
+            select(Fanfic).where(
+                Fanfic.completion_status != "complete",
+                Fanfic.deleted_at.is_(None),
+                Fanfic.title != "Pending scrape...",  # skip stubs
+            )
+        )
+        ongoing_fanfics = fanfic_result.scalars().all()
+        logger.info("auto_update_task ongoing fanfics found=%d", len(ongoing_fanfics))
+
+        # --- Series comics (toongod + hentai20) ---
+        comic_result = await db.execute(
+            select(Comic).where(
+                Comic.source_key.in_([SourceKey.TOONGOD, SourceKey.HENTAI20]),
+                Comic.deleted_at.is_(None),
+                Comic.title != "Pending scrape...",  # skip stubs
+            )
+        )
+        series_comics = comic_result.scalars().all()
+        logger.info("auto_update_task series comics found=%d", len(series_comics))
+
+        jobs_to_add = []
+
+        for fanfic in ongoing_fanfics:
+            if fanfic.id in active_story_ids:
+                skipped_active += 1
+                continue
+            job = ScrapeJob(
+                content_type="fanfic",
+                story_id=fanfic.id,
+                source_url=fanfic.source_url,
+                source_key=fanfic.source_key,
+                job_type=JobType.DELTA,
+                status=JobStatus.QUEUED,
+            )
+            jobs_to_add.append(job)
+
+        for comic in series_comics:
+            if comic.id in active_story_ids:
+                skipped_active += 1
+                continue
+            job = ScrapeJob(
+                content_type="comic",
+                story_id=comic.id,
+                source_url=comic.source_url,
+                source_key=comic.source_key,
+                job_type=JobType.DELTA,
+                status=JobStatus.QUEUED,
+            )
+            jobs_to_add.append(job)
+
+        if jobs_to_add:
+            db.add_all(jobs_to_add)
+            await db.commit()
+            for job in jobs_to_add:
+                await db.refresh(job)
+
+        logger.info(
+            "auto_update_task jobs_created=%d skipped_active=%d",
+            len(jobs_to_add),
+            skipped_active,
+        )
+
+    # Enqueue all created jobs into ARQ outside the DB session
+    if jobs_to_add:
+        try:
+            r = await aioredis.from_url(settings.redis_url)
+            arq_redis = ArqRedis(r.connection_pool)
+            for job in jobs_to_add:
+                task_name = "comic_scrape_task" if job.content_type == "comic" else "fanfic_scrape_task"
+                await arq_redis.enqueue_job(task_name, str(job.id))
+                queued += 1
+            await arq_redis.aclose()
+            logger.info("auto_update_task enqueued=%d", queued)
+        except Exception as e:
+            logger.error("auto_update_task ARQ enqueue failed | error=%s", e)
+
+    logger.info("auto_update_task complete | queued=%d skipped_active=%d", queued, skipped_active)

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -6,6 +6,7 @@ from app.core.logging_config import configure_logging
 from app.tasks.comic_scrape_task import comic_scrape_task
 from app.tasks.fanfic_scrape_task import fanfic_scrape_task
 from app.tasks.cleanup_task import cleanup_task
+from app.tasks.auto_update_task import auto_update_task
 
 # Configure logging at import time — arq starts via CLI so main.py never runs
 configure_logging()
@@ -27,7 +28,10 @@ async def shutdown(ctx: dict) -> None:
 
 class WorkerSettings:
     functions = [comic_scrape_task, fanfic_scrape_task]
-    cron_jobs = [cron(cleanup_task, hour=3, minute=0)]
+    cron_jobs = [
+        cron(cleanup_task, hour=3, minute=0),           # nightly at 03:00 UTC
+        cron(auto_update_task, hour={0, 6, 12, 18}, minute=0),  # every 6 hours
+    ]
     on_startup = startup
     on_shutdown = shutdown
     max_jobs = settings.arq_max_jobs

--- a/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Browser/ComicBrowserView.swift
+++ b/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Browser/ComicBrowserView.swift
@@ -143,7 +143,8 @@ final class ComicBrowserViewModel {
 
         do {
             let response: ScrapeJobResponse = try await APIClient.shared.request(.initiateScrape(request))
-            showToast(ScrapeToast(message: "Scrape queued", isSuccess: true))
+            let alreadyDone = response.status == "complete" || response.status == "partial"
+            showToast(ScrapeToast(message: alreadyDone ? "Already in library" : "Scrape queued", isSuccess: true))
             return LocalScrapeJob(
                 id: response.id,
                 contentType: response.contentType,

--- a/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/ViewModels/ComicLibraryViewModel.swift
+++ b/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/ViewModels/ComicLibraryViewModel.swift
@@ -57,6 +57,23 @@ final class ComicLibraryViewModel {
                 }
             }
             try modelContext.save()
+
+            // Sync server reading progress — restores position after a SwiftData wipe.
+            // Only advances local progress; never overwrites a chapter the user has read further.
+            let progressList: [ProgressResponse] = try await APIClient.shared.request(.allProgress(contentType: "comic"))
+            let progressByStoryId = Dictionary(uniqueKeysWithValues: progressList.map { ($0.storyId, $0) })
+
+            let allComicsDescriptor = FetchDescriptor<LocalComic>()
+            let allComics = (try? modelContext.fetch(allComicsDescriptor)) ?? []
+            for comic in allComics {
+                guard let progress = progressByStoryId[comic.id],
+                      progress.lastChapterNumber > comic.lastReadChapterNumber else { continue }
+                comic.lastReadChapterNumber = progress.lastChapterNumber
+                if comic.totalChapters > 0 {
+                    comic.progressPercent = Double(progress.lastChapterNumber) / Double(comic.totalChapters)
+                }
+            }
+            try modelContext.save()
         } catch let error as APIError where error == .cookieRefreshNeeded {
             errorMessage = "Browser refresh needed"
         } catch {

--- a/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Browser/FanficBrowserView.swift
+++ b/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Browser/FanficBrowserView.swift
@@ -149,7 +149,8 @@ final class FanficBrowserViewModel {
 
         do {
             let response: ScrapeJobResponse = try await APIClient.shared.request(.initiateScrape(request))
-            showToast(ScrapeToast(message: "Scrape queued", isSuccess: true))
+            let alreadyDone = response.status == "complete" || response.status == "partial"
+            showToast(ScrapeToast(message: alreadyDone ? "Already in library" : "Scrape queued", isSuccess: true))
             return LocalScrapeJob(
                 id: response.id,
                 contentType: response.contentType,

--- a/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/ViewModels/FanficLibraryViewModel.swift
+++ b/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/ViewModels/FanficLibraryViewModel.swift
@@ -82,6 +82,24 @@ final class FanficLibraryViewModel {
                 }
             }
             try modelContext.save()
+
+            // Sync server reading progress — restores position after a SwiftData wipe.
+            // Only advances local progress; never overwrites a chapter the user has read further.
+            let progressList: [ProgressResponse] = try await APIClient.shared.request(.allProgress(contentType: "fanfic"))
+            let progressByStoryId = Dictionary(uniqueKeysWithValues: progressList.map { ($0.storyId, $0) })
+
+            let allFanficsDescriptor = FetchDescriptor<LocalFanfic>()
+            let allFanfics = (try? modelContext.fetch(allFanficsDescriptor)) ?? []
+            for fanfic in allFanfics {
+                guard let progress = progressByStoryId[fanfic.id],
+                      progress.lastChapterNumber > fanfic.lastReadChapterNumber else { continue }
+                fanfic.lastReadChapterNumber = progress.lastChapterNumber
+                fanfic.scrollOffsetPercent = progress.scrollOffsetPercent
+                if fanfic.totalChapters > 0 {
+                    fanfic.progressPercent = Double(progress.lastChapterNumber) / Double(fanfic.totalChapters)
+                }
+            }
+            try modelContext.save()
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ios/Astral/Packages/Networking/Sources/Networking/Endpoints.swift
+++ b/ios/Astral/Packages/Networking/Sources/Networking/Endpoints.swift
@@ -171,6 +171,14 @@ public extension Endpoint {
     static func getProgress(type: String, storyId: UUID) -> Endpoint {
         Endpoint(path: "/progress/\(type)/\(storyId)")
     }
+
+    /// Fetch all progress records for a content type in one call.
+    /// Used by library ViewModels on refresh to restore reading position after a SwiftData wipe.
+    static func allProgress(contentType: String) -> Endpoint {
+        Endpoint(path: "/progress", queryItems: [
+            URLQueryItem(name: "content_type", value: contentType),
+        ])
+    }
 }
 
 // MARK: - Health


### PR DESCRIPTION
## Summary

- **Auto-update scheduler**: New ARQ cron job (`auto_update_task`) fires every 6 hours and queues delta scrape jobs for all ongoing fanfics and series comics (toongod/hentai20). Skips stories with an already-active job. nhentai is excluded (single galleries, no new chapters).
- **Bulk progress endpoint**: `GET /api/v1/progress?content_type=comic|fanfic` returns all progress records in one API call. iOS library ViewModels now call this on each refresh and sync server progress into SwiftData — restores reading position after a local data wipe without user action.
- **Duplicate scrape guard**: `initiate_scrape()` now returns the existing completed/partial job if the source URL was already scraped successfully, instead of queuing a new INITIAL job that would re-scrape and overwrite existing chapters. Browser VMs show "Already in library" toast in this case.

## Test plan

- [ ] Trigger a scrape, let it complete, then tap the scrape button again on the same URL — should get "Already in library" toast, no new job created
- [ ] Clear SwiftData, relaunch app, tap refresh on library — reading progress (chapter number, scroll offset) should be restored from server
- [ ] Verify `GET /api/v1/progress?content_type=comic` returns all records
- [ ] Confirm `auto_update_task` appears in ARQ worker cron list on startup logs
- [ ] Add an ongoing fanfic, wait for next 6h cron window or trigger manually — delta job should appear in scrapes view

🤖 Generated with [Claude Code](https://claude.com/claude-code)