### PR TITLE
[backend][ios] fix scraper selectors and missing metadata

### DIFF
--- a/backend/app/scrapers/comic/hentai20.py
+++ b/backend/app/scrapers/comic/hentai20.py
@@ -49,6 +49,14 @@ class Hentai20Scraper(BaseScraper):
         if thumb_tag:
             thumbnail_url = (thumb_tag.get("data-src") or thumb_tag.get("src") or "").strip() or None
 
+        # Author (Madara theme — same selector as toongod)
+        author_tag = soup.select_one(".author-content a")
+        authors = [author_tag.get_text(strip=True)] if author_tag else []
+
+        # Genre tags (Madara theme)
+        genre_tags = soup.select(".genres-content a")
+        tags = [{"name": a.get_text(strip=True), "tag_type": "genre"} for a in genre_tags]
+
         slug = _slug(url)
         chapter_links = soup.find_all(
             "a", href=re.compile(rf"hentai20\.io/{re.escape(slug)}-chapter-\d")
@@ -62,6 +70,8 @@ class Hentai20Scraper(BaseScraper):
             source_key=self.source_key,
             source_id=slug,
             description=description,
+            authors=authors,
+            tags=tags,
             thumbnail_url=thumbnail_url,
             total_chapters=total_chapters,
         )

--- a/backend/app/scrapers/comic/toongod.py
+++ b/backend/app/scrapers/comic/toongod.py
@@ -5,7 +5,7 @@ from app.core.constants import SourceKey
 
 
 def _slug(url: str) -> str:
-    m = re.search(r"/webtoon/([^/?#]+)", url)
+    m = re.search(r"/(?:webtoon|manga)/([^/?#]+)", url)
     if not m:
         raise ValueError(f"Cannot extract toongod slug from URL: {url}")
     return m.group(1)
@@ -20,7 +20,7 @@ class ToongodScraper(BaseScraper):
 
     async def get_story_metadata(self, url: str) -> StoryMetadata:
         # Normalise to series root (strip any chapter suffix)
-        series_url = re.sub(r"/chapter-[^/]+/?$", "/", url)
+        series_url = re.sub(r"/chapter-[^/]+/?$", "/", url).replace("toongod.com", "toongod.org")
         html = await self._fetch(series_url)
         soup = BeautifulSoup(html, "lxml")
 

--- a/backend/app/scrapers/fanfic/ffnet.py
+++ b/backend/app/scrapers/fanfic/ffnet.py
@@ -44,8 +44,79 @@ class FanfictionNetScraper(BaseScraper):
             options = chap_select.find_all("option")
             total_chapters = len(options) if options else 1
         else:
-            # No dropdown means single-chapter story
             total_chapters = 1
+
+        # Parse the metadata line:
+        # "Rated: Fiction T - English - Adventure/Romance - Harry P., ... - Words: 184,603 ..."
+        rating = None
+        language = None
+        word_count = None
+        characters = None
+        fandom = None
+        tags = []
+        completion_status = "ongoing"
+        published_at = None
+        updated_at_source = None
+
+        # Fandom from breadcrumb (e.g. "Harry Potter")
+        breadcrumb_links = soup.select("#pre_story_links a")
+        if len(breadcrumb_links) >= 2:
+            fandom = breadcrumb_links[-1].get_text(strip=True)
+
+        # Metadata span — last span in #profile_top
+        meta_spans = soup.select("#profile_top span.xgray")
+        meta_text = meta_spans[-1].get_text() if meta_spans else ""
+        if not meta_text:
+            # Fallback: grab the full text of the container
+            profile = soup.select_one("#profile_top")
+            meta_text = profile.get_text() if profile else ""
+
+        # Rating: "Fiction T", "Fiction M", "Fiction K+", etc.
+        m = re.search(r"Rated:\s*(?:Fiction\s+)?([TKMA][+]?)", meta_text)
+        if m:
+            rating = m.group(1)
+
+        # Language
+        m = re.search(r"Fiction\s+\S+\s+-\s+(\w+)\s+-", meta_text)
+        if m:
+            language = m.group(1)
+
+        # Genre (between language and characters/chapters marker)
+        m = re.search(r"Fiction\s+\S+\s+-\s+\w+\s+-\s+([^-]+?)\s+-", meta_text)
+        if m:
+            genre_text = m.group(1).strip()
+            # Genres like "Adventure/Romance" or "Drama"
+            for g in genre_text.split("/"):
+                g = g.strip()
+                if g and not re.match(r"^(Chapters|Words|Reviews)", g):
+                    tags.append({"name": g, "tag_type": "genre"})
+
+        # Characters — text segment that contains character names before " - Chapters:"
+        m = re.search(r"-\s+([A-Z][\w. ]+(?:,\s*[A-Z][\w. ]+)*)\s+-\s*Chapters:", meta_text)
+        if m:
+            characters = m.group(1).strip()
+
+        # Words
+        m = re.search(r"Words:\s*([\d,]+)", meta_text)
+        if m:
+            try:
+                word_count = int(m.group(1).replace(",", ""))
+            except ValueError:
+                pass
+
+        # Published
+        m = re.search(r"Published:\s*([A-Za-z]+ \d+,? \d{4})", meta_text)
+        if m:
+            published_at = m.group(1)
+
+        # Updated
+        m = re.search(r"Updated:\s*([A-Za-z]+ \d+,? \d{4})", meta_text)
+        if m:
+            updated_at_source = m.group(1)
+
+        # Completion — FFNet shows "Status: Complete" in metadata
+        if "Status: Complete" in meta_text or "Complete" in meta_text:
+            completion_status = "complete"
 
         return StoryMetadata(
             title=title,
@@ -55,6 +126,15 @@ class FanfictionNetScraper(BaseScraper):
             description=description,
             authors=authors,
             total_chapters=total_chapters,
+            language=language,
+            fandom=fandom,
+            rating=rating,
+            characters=characters,
+            word_count=word_count,
+            completion_status=completion_status,
+            published_at=published_at,
+            updated_at_source=updated_at_source,
+            tags=tags,
         )
 
     async def get_chapter_list(self, story_url: str) -> list[ChapterInfo]:

--- a/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Browser/ComicBrowserView.swift
+++ b/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Browser/ComicBrowserView.swift
@@ -113,7 +113,7 @@ final class ComicBrowserViewModel {
         }
         switch selectedSource {
         case .nhentai: return URL(string: "https://nhentai.net")!
-        case .toongod: return URL(string: "https://www.toongod.com")!
+        case .toongod: return URL(string: "https://www.toongod.org")!
         case .hentai20: return URL(string: "https://hentai20.io")!
         }
     }

--- a/ios/Astral/Packages/Networking/Sources/Networking/CookieStore.swift
+++ b/ios/Astral/Packages/Networking/Sources/Networking/CookieStore.swift
@@ -12,7 +12,7 @@ public final class CookieStore: Sendable {
     /// Maps source_key to the actual cookie domain used by the site.
     private let sourceDomains: [String: String] = [
         "nhentai": "nhentai.net",
-        "toongod": "toongod.com",
+        "toongod": "toongod.org",
         "hentai20": "hentai20.io",
         "ao3": "archiveofourown.org",
         "ffnet": "fanfiction.net",


### PR DESCRIPTION
## Summary

Tested all 5 scrapers against live sites using Playwright MCP. Found and fixed 4 issues:

- **toongod domain change**: Site migrated from `toongod.com` → `toongod.org`. Updated CookieStore domain mapping and iOS browser source URL. Also fixed `_slug()` to handle both `/webtoon/` and `/manga/` URL patterns (iOS allowed both but scraper only matched `/webtoon/`).
- **FFNet missing metadata**: Scraper only extracted title/author/description/chapters. Now parses the metadata line for rating, language, genre tags, characters, word count, published/updated dates, and completion status. Fandom extracted from breadcrumb nav.
- **hentai20 missing tags/authors**: Added `.author-content` and `.genres-content` Madara theme selectors (same theme as toongod). Previously returned empty arrays.
- **AO3**: All selectors verified correct against live page — no changes needed.

## Test plan

- [ ] Scrape a toongod series via `/manga/` URL — should succeed (previously crashed on slug extraction)
- [ ] Verify toongod cookies are harvested correctly after domain change to .org
- [ ] Scrape an FFNet story — verify fandom, rating, word count, completion status populate in DB
- [ ] Scrape a hentai20 manga — verify genre tags and author appear in library view
- [ ] Scrape an AO3 work — confirm no regressions (selectors unchanged)
- [ ] Scrape an nhentai gallery — confirm no regressions (scraper unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)