### PR TITLE
[ios] fix tab switcher icon and styling

### DIFF
--- a/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/ComicTabView.swift
+++ b/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/ComicTabView.swift
@@ -50,18 +50,25 @@ public struct ComicTabView: View {
                             }
                         } label: {
                             HStack(spacing: 6) {
+                                Image(systemName: "book.fill")
+                                    .font(.system(size: 14, weight: .semibold))
                                 Text("Comics")
-                                    .font(AstralTypography.title)
-                                    .foregroundStyle(AstralColors.white)
+                                    .font(AstralTypography.titleSmall)
                                 Image(systemName: "chevron.down")
-                                    .font(.caption.weight(.semibold))
+                                    .font(.caption2.weight(.semibold))
                                     .foregroundStyle(AstralColors.muted)
                             }
+                            .foregroundStyle(AstralColors.gold)
                             .padding(.horizontal, 14)
-                            .padding(.vertical, 6)
+                            .padding(.vertical, 8)
                             .background(AstralColors.elevated)
                             .clipShape(Capsule())
+                            .overlay(
+                                Capsule()
+                                    .strokeBorder(AstralColors.gold.opacity(0.3), lineWidth: 1)
+                            )
                         }
+                        .tint(AstralColors.gold)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         Button {

--- a/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/FanficTabView.swift
+++ b/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/FanficTabView.swift
@@ -49,18 +49,25 @@ public struct FanficTabView: View {
                             }
                         } label: {
                             HStack(spacing: 6) {
+                                Image(systemName: "scroll.fill")
+                                    .font(.system(size: 14, weight: .semibold))
                                 Text("Fan Fiction")
-                                    .font(AstralTypography.title)
-                                    .foregroundStyle(AstralColors.white)
+                                    .font(AstralTypography.titleSmall)
                                 Image(systemName: "chevron.down")
-                                    .font(.caption.weight(.semibold))
+                                    .font(.caption2.weight(.semibold))
                                     .foregroundStyle(AstralColors.muted)
                             }
+                            .foregroundStyle(AstralColors.gold)
                             .padding(.horizontal, 14)
-                            .padding(.vertical, 6)
+                            .padding(.vertical, 8)
                             .background(AstralColors.elevated)
                             .clipShape(Capsule())
+                            .overlay(
+                                Capsule()
+                                    .strokeBorder(AstralColors.gold.opacity(0.3), lineWidth: 1)
+                            )
                         }
+                        .tint(AstralColors.gold)
                     }
                     ToolbarItem(placement: .topBarTrailing) {
                         HStack(spacing: 16) {


### PR DESCRIPTION
## Summary

- Add `book.fill` / `scroll.fill` icon to the tab switcher capsule so users can identify the active tab at a glance
- Apply `.tint(AstralColors.gold)` on the `Menu` to override SwiftUI's default blue accent color
- Add subtle gold border on the capsule for better visibility against the dark background

## Test plan

- [ ] Launch app — tab switcher capsule shows gold book icon + "Comics" text + chevron
- [ ] Tap capsule → menu opens with both tab options showing icons
- [ ] Switch to Fan Fiction → capsule updates to scroll icon + "Fan Fiction"
- [ ] Verify gold color applies (not system blue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)