### PR TITLE
[ios] AST-9 fix downloaded comic chapters failing to render

### DIFF
--- a/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Reader/ComicReaderView.swift
+++ b/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Reader/ComicReaderView.swift
@@ -98,7 +98,7 @@ struct ComicReaderView: View {
                 ProgressView()
                     .tint(AstralColors.gold)
                     .scaleEffect(1.2)
-            } else if pages.isEmpty {
+            } else if pages.isEmpty && (localPageURLs?.isEmpty ?? true) {
                 EmptyStateView(
                     icon: "photo.on.rectangle.angled",
                     title: "No Pages",

--- a/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Reader/ComicReaderView.swift
+++ b/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Reader/ComicReaderView.swift
@@ -958,19 +958,22 @@ struct ComicReaderView: View {
         }
 
         // Try local files first (device-saved chapter)
+        AstralLogger.info("loadPages: chapter \(chapter.id) state — isDownloaded=\(chapter.isDownloaded), downloadStatus=\(chapter.downloadStatus.rawValue), totalPages=\(chapter.totalPages), localPagesPath=\(chapter.localPagesPath ?? "nil")", context: "ComicReader")
         if let urls = ChapterDownloadService.shared.localPageURLs(for: chapter) {
             if urls.count == chapter.totalPages || chapter.totalPages == 0 {
                 localPageURLs = urls
                 pages = []
-                AstralLogger.info("loadPages: using \(urls.count) local pages", context: "ComicReader")
+                AstralLogger.info("loadPages: using \(urls.count) local pages (first=\(urls.first?.lastPathComponent ?? "nil"))", context: "ComicReader")
                 isLoading = false
                 return
             } else {
                 // Page count mismatch — partial/corrupt download
                 chapter.downloadStatus = .failed
                 chapter.downloadError = "Expected \(chapter.totalPages) pages, found \(urls.count)"
-                AstralLogger.warning("loadPages: local page count mismatch (\(urls.count)/\(chapter.totalPages)), falling through to network", context: "ComicReader")
+                AstralLogger.warning("loadPages: local page count mismatch (urls=\(urls.count), totalPages=\(chapter.totalPages), first=\(urls.first?.lastPathComponent ?? "nil")), falling through to network", context: "ComicReader")
             }
+        } else {
+            AstralLogger.warning("loadPages: localPageURLs returned nil for chapter \(chapter.id)", context: "ComicReader")
         }
 
         localPageURLs = nil

--- a/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Services/ChapterDownloadService.swift
+++ b/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/Services/ChapterDownloadService.swift
@@ -147,15 +147,27 @@ final class ChapterDownloadService {
 
     /// Load locally saved page URLs for a chapter. Returns nil if not available.
     func localPageURLs(for chapter: LocalComicChapter) -> [URL]? {
-        guard let relativePath = chapter.localPagesPath else { return nil }
+        guard let relativePath = chapter.localPagesPath else {
+            AstralLogger.warning("localPageURLs: localPagesPath nil for chapter \(chapter.id) (isDownloaded=\(chapter.isDownloaded), downloadStatus=\(chapter.downloadStatus.rawValue))", context: "Download")
+            return nil
+        }
         let chapterDir = documentsDir.appendingPathComponent(relativePath)
-        guard let files = try? fileManager.contentsOfDirectory(at: chapterDir, includingPropertiesForKeys: nil) else {
+        let files: [URL]
+        do {
+            files = try fileManager.contentsOfDirectory(at: chapterDir, includingPropertiesForKeys: nil)
+        } catch {
+            AstralLogger.warning("localPageURLs: contentsOfDirectory failed at \(chapterDir.path): \(error)", context: "Download")
             return nil
         }
         let sorted = files
             .filter { $0.pathExtension == "jpg" || $0.pathExtension == "png" }
             .sorted { $0.lastPathComponent < $1.lastPathComponent }
-        return sorted.isEmpty ? nil : sorted
+        if sorted.isEmpty {
+            let rawNames = files.map { $0.lastPathComponent }
+            AstralLogger.warning("localPageURLs: no .jpg/.png files after filter at \(chapterDir.path); raw files=\(rawNames)", context: "Download")
+            return nil
+        }
+        return sorted
     }
 
     // MARK: - Deletion


### PR DESCRIPTION
## Summary

Downloaded comic chapters were hitting the "No Pages, this chapter hasn't been scraped yet" empty state instead of rendering from disk.

Root cause: `ComicReaderView.body` gated the empty state on `pages.isEmpty` alone. `loadPages()` intentionally sets `pages = []` when it picks the local-file branch (because `localPageURLs` handles rendering), so every downloaded chapter fell into the empty state — even when 10+ valid local pages were sitting on disk.

Fix: only show the empty state when both `pages` AND `localPageURLs` are empty. Also adds diagnostic logs to three silent failure branches in the local-load path for future debugging.

Closes [AST-9](https://linear.app/nnetraganti/issue/AST-9/reader-downloaded-comics-fail-to-load-pages-in-reader).

## Commits

- **3b532dc** — diagnostic logs for the three local-load failure branches (`localPagesPath == nil`, enumeration failure, post-filter empty files, page-count mismatch). Kept in for future regressions.
- **`HEAD`** — one-line guard fix for the empty-state branch.

## Test plan

- [x] `xcodebuild -scheme Astral -sdk iphonesimulator build` succeeds
- [x] Manual: download a chapter, kill app, reopen the downloaded chapter — pages render from disk, no network call for `/pages`, no "No Pages" screen
- [x] Diagnostic logs confirm local path: `loadPages: using 10 local pages (first=page_0001.jpg)` without fallthrough to network

🤖 Generated with [Claude Code](https://claude.com/claude-code)