### PR TITLE
[ios][backend] AST-12 fanfic thumbnail fallback system

### DIFF
--- a/backend/app/api/v1/routes/fanfic_thumbnails.py
+++ b/backend/app/api/v1/routes/fanfic_thumbnails.py
@@ -1,0 +1,24 @@
+import random
+from typing import Union
+from fastapi import APIRouter, Query
+from app.schemas.fanfic_thumbnail import (
+    RandomThumbnailResponse,
+    RandomThumbnailBatchResponse,
+    FANFIC_THUMBNAIL_COUNT,
+)
+
+router = APIRouter(prefix="/fanfic-thumbnails", tags=["fanfic-thumbnails"])
+
+
+@router.get("/random")
+async def random_fanfic_thumbnail(
+    count: int = Query(default=1, ge=1, le=FANFIC_THUMBNAIL_COUNT),
+) -> Union[RandomThumbnailResponse, RandomThumbnailBatchResponse]:
+    if count == 1:
+        n = random.randint(1, FANFIC_THUMBNAIL_COUNT)
+        return RandomThumbnailResponse(path=f"fanfic-thumbnails/{n}.jpg")
+    paths = [
+        f"fanfic-thumbnails/{random.randint(1, FANFIC_THUMBNAIL_COUNT)}.jpg"
+        for _ in range(count)
+    ]
+    return RandomThumbnailBatchResponse(paths=paths)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.logging_config import configure_logging
 from app.db.database import engine, Base
 from app.models import *  # noqa: F401, F403 — import all models so Base.metadata is populated
-from app.api.v1.routes import comics, fanfic, scrape, authors, progress, health, stats
+from app.api.v1.routes import comics, fanfic, scrape, authors, progress, health, stats, fanfic_thumbnails
 
 configure_logging()
 logger = logging.getLogger(__name__)
@@ -61,5 +61,6 @@ app.include_router(scrape.router, prefix="/api/v1")
 app.include_router(authors.router, prefix="/api/v1")
 app.include_router(progress.router, prefix="/api/v1")
 app.include_router(stats.router, prefix="/api/v1")
+app.include_router(fanfic_thumbnails.router, prefix="/api/v1")
 
 logger.info("Astral API routes registered")

--- a/backend/app/schemas/fanfic_thumbnail.py
+++ b/backend/app/schemas/fanfic_thumbnail.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+FANFIC_THUMBNAIL_COUNT = 50
+
+
+class RandomThumbnailResponse(BaseModel):
+    path: str  # returned when count=1 or count absent
+
+
+class RandomThumbnailBatchResponse(BaseModel):
+    paths: list[str]  # returned when count > 1; length == min(count, 50)

--- a/backend/scripts/seed_fanfic_thumbnails.py
+++ b/backend/scripts/seed_fanfic_thumbnails.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Seed 50 fanfic thumbnail JPGs into the astral_media volume.
+Usage: python scripts/seed_fanfic_thumbnails.py [--force] [--output-dir /path]
+
+Requires: Pillow (`pip install pillow`)
+
+This script is a deploy-time step — run once inside the backend container:
+  docker compose exec backend python scripts/seed_fanfic_thumbnails.py
+
+Re-run with --force to overwrite existing files (e.g. when replacing with curated art).
+
+TODO: Replace generated gradient images with curated manga/book-cover art by dropping
+      real 400x600 JPGs named 1.jpg–50.jpg into the volume and re-running with --force.
+"""
+import argparse
+import os
+from pathlib import Path
+from PIL import Image, ImageDraw, ImageFont
+
+COLORS = [
+    (0x2A, 0x2A, 0x4A),  # deep indigo
+    (0x4A, 0x2A, 0x2A),  # deep burgundy
+    (0x2A, 0x4A, 0x34),  # deep forest
+    (0x40, 0x32, 0x4A),  # deep plum
+    (0x32, 0x40, 0x44),  # deep teal
+    (0x3A, 0x3A, 0x2A),  # deep olive
+]
+GLYPHS = ["📖", "📜", "✒️", "🌟", "📚", "🖊️", "🌙", "⭐"]
+WIDTH, HEIGHT = 400, 600
+COUNT = 50
+
+
+def make_gradient(color_top, color_bot, size=(WIDTH, HEIGHT)):
+    img = Image.new("RGB", size)
+    for y in range(size[1]):
+        t = y / size[1]
+        r = int(color_top[0] * (1 - t) + color_bot[0] * t)
+        g = int(color_top[1] * (1 - t) + color_bot[1] * t)
+        b = int(color_top[2] * (1 - t) + color_bot[2] * t)
+        ImageDraw.Draw(img).line([(0, y), (size[0], y)], fill=(r, g, b))
+    return img
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--output-dir", default="/mnt/astral-media/fanfic-thumbnails")
+    args = parser.parse_args()
+
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    for n in range(1, COUNT + 1):
+        dest = out / f"{n}.jpg"
+        if dest.exists() and not args.force:
+            print(f"  skip {dest.name} (exists)")
+            continue
+        color_a = COLORS[(n - 1) % len(COLORS)]
+        color_b = COLORS[n % len(COLORS)]
+        img = make_gradient(color_a, color_b)
+        # Overlay glyph at 30% opacity
+        draw = ImageDraw.Draw(img, "RGBA")
+        glyph = GLYPHS[(n - 1) % len(GLYPHS)]
+        draw.text(
+            (WIDTH // 2, HEIGHT // 2),
+            glyph,
+            fill=(255, 255, 255, 77),
+            anchor="mm",
+            font=ImageFont.load_default(size=80),
+        )
+        img.save(dest, "JPEG", quality=70, optimize=True)
+        print(f"  wrote {dest.name}")
+
+    print(f"Done — {COUNT} thumbnails in {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/api/test_fanfic_thumbnails.py
+++ b/backend/tests/api/test_fanfic_thumbnails.py
@@ -1,0 +1,75 @@
+import re
+import pytest
+
+
+VALID_PATH_RE = re.compile(r"fanfic-thumbnails/([1-9]|[1-4][0-9]|50)\.jpg")
+
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_no_count_returns_single_path(client):
+    """GET /fanfic-thumbnails/random with no count returns { path: ... }."""
+    resp = await client.get("/fanfic-thumbnails/random")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "path" in data
+    assert "paths" not in data
+    assert VALID_PATH_RE.fullmatch(data["path"]), f"Invalid path: {data['path']}"
+
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_count_1_returns_single_path(client):
+    """GET /fanfic-thumbnails/random?count=1 returns { path: ... } (not batch)."""
+    resp = await client.get("/fanfic-thumbnails/random?count=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "path" in data
+    assert "paths" not in data
+    assert VALID_PATH_RE.fullmatch(data["path"]), f"Invalid path: {data['path']}"
+
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_batch_count_5_returns_paths_array(client):
+    """GET /fanfic-thumbnails/random?count=5 returns { paths: [...] } of length 5."""
+    resp = await client.get("/fanfic-thumbnails/random?count=5")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "paths" in data
+    assert "path" not in data
+    assert len(data["paths"]) == 5
+    for path in data["paths"]:
+        assert VALID_PATH_RE.fullmatch(path), f"Invalid path in batch: {path}"
+
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_count_above_cap_rejected(client):
+    """GET /fanfic-thumbnails/random?count=60 returns 422 (server enforces le=50)."""
+    resp = await client.get("/fanfic-thumbnails/random?count=60")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_count_zero_rejected(client):
+    """GET /fanfic-thumbnails/random?count=0 returns 422 (ge=1)."""
+    resp = await client.get("/fanfic-thumbnails/random?count=0")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_batch_count_50_returns_50_paths(client):
+    """GET /fanfic-thumbnails/random?count=50 returns exactly 50 paths."""
+    resp = await client.get("/fanfic-thumbnails/random?count=50")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "paths" in data
+    assert len(data["paths"]) == 50
+
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_varies(client):
+    """20 consecutive calls should yield at least 3 distinct paths (probabilistic)."""
+    paths = set()
+    for _ in range(20):
+        resp = await client.get("/fanfic-thumbnails/random")
+        assert resp.status_code == 200
+        paths.add(resp.json()["path"])
+    assert len(paths) >= 3, f"Expected >= 3 distinct paths, got {len(paths)}: {paths}"

--- a/docs/superpowers/plans/2026-04-17-ast12-fanfic-thumbnail-fallback.md
+++ b/docs/superpowers/plans/2026-04-17-ast12-fanfic-thumbnail-fallback.md
@@ -1,0 +1,313 @@
+# AST-12 — Fanfic Thumbnail Fallback: Implementation Plan
+
+**Date**: 2026-04-17
+**Issue**: AST-12
+**Spec**: `docs/superpowers/specs/2026-04-17-ast12-fanfic-thumbnail-fallback-design.md`
+**Branch**: `feature/ast-12-fanfic-thumbnail-fallback`
+
+---
+
+## Task 1 — Backend: `GET /api/v1/fanfic-thumbnails/random` endpoint
+
+### Files
+
+- **New**: `backend/app/schemas/fanfic_thumbnail.py`
+- **New**: `backend/app/api/v1/routes/fanfic_thumbnails.py`
+- **Modify**: `backend/app/main.py` — add `include_router` call
+- **Modify**: `backend/app/api/v1/routes/__init__.py` (if exists) or just import directly in main.py
+
+### Code
+
+**`backend/app/schemas/fanfic_thumbnail.py`**
+```python
+from pydantic import BaseModel
+
+FANFIC_THUMBNAIL_COUNT = 50
+
+class RandomThumbnailResponse(BaseModel):
+    path: str
+```
+
+**`backend/app/api/v1/routes/fanfic_thumbnails.py`**
+```python
+import random
+from fastapi import APIRouter
+from app.schemas.fanfic_thumbnail import RandomThumbnailResponse, FANFIC_THUMBNAIL_COUNT
+
+router = APIRouter(prefix="/fanfic-thumbnails", tags=["fanfic-thumbnails"])
+
+@router.get("/random", response_model=RandomThumbnailResponse)
+async def random_fanfic_thumbnail() -> RandomThumbnailResponse:
+    n = random.randint(1, FANFIC_THUMBNAIL_COUNT)
+    return RandomThumbnailResponse(path=f"fanfic-thumbnails/{n}.jpg")
+```
+
+**Add to `backend/app/main.py`** (after existing imports line):
+```python
+from app.api.v1.routes import fanfic_thumbnails
+# ...
+app.include_router(fanfic_thumbnails.router, prefix="/api/v1")
+```
+
+### Commit message
+```
+[backend] AST-12 add GET /api/v1/fanfic-thumbnails/random endpoint
+```
+
+---
+
+## Task 2 — Backend: image seeding script
+
+### Files
+
+- **New**: `backend/scripts/seed_fanfic_thumbnails.py`
+
+### Code
+
+Script generates 50 gradient JPGs (400×600) using Pillow. Uses the 6 Astral dark-theme colors. Each image has a gradient direction and an optional Unicode glyph overlay (book/scroll/quill symbol at large size in white at low opacity).
+
+```python
+#!/usr/bin/env python3
+"""
+Seed 50 fanfic thumbnail JPGs into the astral_media volume.
+Usage: python scripts/seed_fanfic_thumbnails.py [--force] [--output-dir /path]
+
+Requires: Pillow (`pip install pillow`)
+"""
+import argparse
+import os
+from pathlib import Path
+from PIL import Image, ImageDraw, ImageFont
+
+COLORS = [
+    (0x2A, 0x2A, 0x4A),  # deep indigo
+    (0x4A, 0x2A, 0x2A),  # deep burgundy
+    (0x2A, 0x4A, 0x34),  # deep forest
+    (0x40, 0x32, 0x4A),  # deep plum
+    (0x32, 0x40, 0x44),  # deep teal
+    (0x3A, 0x3A, 0x2A),  # deep olive
+]
+GLYPHS = ["📖", "📜", "✒️", "🌟", "📚", "🖊️", "🌙", "⭐"]
+WIDTH, HEIGHT = 400, 600
+COUNT = 50
+
+def make_gradient(color_top, color_bot, size=(WIDTH, HEIGHT)):
+    img = Image.new("RGB", size)
+    for y in range(size[1]):
+        t = y / size[1]
+        r = int(color_top[0] * (1 - t) + color_bot[0] * t)
+        g = int(color_top[1] * (1 - t) + color_bot[1] * t)
+        b = int(color_top[2] * (1 - t) + color_bot[2] * t)
+        ImageDraw.Draw(img).line([(0, y), (size[0], y)], fill=(r, g, b))
+    return img
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--output-dir", default="/mnt/astral-media/fanfic-thumbnails")
+    args = parser.parse_args()
+
+    out = Path(args.output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    for n in range(1, COUNT + 1):
+        dest = out / f"{n}.jpg"
+        if dest.exists() and not args.force:
+            print(f"  skip {dest.name} (exists)")
+            continue
+        color_a = COLORS[(n - 1) % len(COLORS)]
+        color_b = COLORS[n % len(COLORS)]
+        img = make_gradient(color_a, color_b)
+        # Overlay glyph at 30% opacity
+        draw = ImageDraw.Draw(img, "RGBA")
+        glyph = GLYPHS[(n - 1) % len(GLYPHS)]
+        draw.text((WIDTH // 2, HEIGHT // 2), glyph, fill=(255, 255, 255, 77),
+                  anchor="mm", font=ImageFont.load_default(size=80))
+        img.save(dest, "JPEG", quality=70, optimize=True)
+        print(f"  wrote {dest.name}")
+
+    print(f"Done — {COUNT} thumbnails in {out}")
+
+if __name__ == "__main__":
+    main()
+```
+
+**Run in container**:
+```bash
+docker compose exec backend python scripts/seed_fanfic_thumbnails.py
+```
+
+**TODO**: Replace generated images with curated manga/book-cover art by dropping real 400×600 JPGs named `1.jpg`–`50.jpg` into the volume and re-running with `--force`.
+
+### Commit message
+```
+[backend] AST-12 add thumbnail seeding script (50 gradient JPGs)
+```
+
+---
+
+## Task 3 — iOS: DTO + APIClient endpoint
+
+### Files
+
+- **Modify**: `ios/Astral/Packages/Networking/Sources/Networking/DTOs/FanficDTOs.swift`
+- **Modify**: `ios/Astral/Packages/Networking/Sources/Networking/Endpoints.swift`
+
+### Code
+
+**FanficDTOs.swift** — add at bottom:
+```swift
+public struct RandomThumbnailResponse: Codable, Sendable {
+    public let path: String
+}
+```
+
+**Endpoints.swift** — add inside `public extension Endpoint` Fanfic section:
+```swift
+static var randomFanficThumbnail: Endpoint {
+    Endpoint(path: "/fanfic-thumbnails/random")
+}
+```
+
+### Commit message
+```
+[ios] AST-12 add RandomThumbnailResponse DTO and randomFanficThumbnail endpoint
+```
+
+---
+
+## Task 4 — iOS: scrape-finalize thumbnail assignment
+
+### Files
+
+- **Modify**: `ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Scrapes/FanficScrapesView.swift`
+
+### Code
+
+In `FanficScrapesView.syncActiveJobs()`, after the existing job-status upsert loop and before `try? modelContext.save()`:
+
+```swift
+// AST-12: assign fallback thumbnails for newly-completed fanfics with nil paths
+for job in fanficJobs where job.status == "complete" || job.status == "partial" {
+    guard let fanfic = fanfics.first(where: { $0.id == job.storyId }),
+          fanfic.thumbnailPath == nil else { continue }
+    if let dto: RandomThumbnailResponse = try? await APIClient.shared.request(.randomFanficThumbnail) {
+        fanfic.thumbnailPath = dto.path
+        AstralLogger.info("Assigned thumbnail \(dto.path) to fanfic \(fanfic.id)", context: "FanficScrapes")
+    }
+}
+```
+
+### Commit message
+```
+[ios] AST-12 assign fallback thumbnail when scrape completes and path is nil
+```
+
+---
+
+## Task 5 — iOS: migration for existing fanfics
+
+### Files
+
+- **Modify**: `ios/Astral/Packages/FanficFeature/Sources/FanficFeature/ViewModels/FanficLibraryViewModel.swift`
+
+### Code
+
+At the end of the `do` block in `fetchFanfics()`, after `lastSyncTime = .now`:
+
+```swift
+// AST-12: one-off migration — assign thumbnails to fanfics with nil paths
+let nilThumbFanfics = allFanfics.filter { $0.thumbnailPath == nil }
+if !nilThumbFanfics.isEmpty {
+    AstralLogger.info("Migration: \(nilThumbFanfics.count) fanfics need thumbnails", context: "FanficLibraryVM")
+    for fanfic in nilThumbFanfics {
+        if let dto: RandomThumbnailResponse = try? await APIClient.shared.request(.randomFanficThumbnail) {
+            fanfic.thumbnailPath = dto.path
+        }
+    }
+    try? modelContext.save()
+    AstralLogger.info("Migration: thumbnail assignment complete", context: "FanficLibraryVM")
+}
+```
+
+Note: `RandomThumbnailResponse` import is available via the `Networking` module already imported in this file.
+
+### Commit message
+```
+[ios] AST-12 migrate existing fanfics with nil thumbnailPath on library sync
+```
+
+---
+
+## Task 6 — iOS: fallback handling verification
+
+### Files
+
+- **Read-only audit**: `ios/Astral/Packages/DesignSystem/Sources/DesignSystem/Components/StoryThumbnail.swift`
+- **Read-only audit**: `ios/Astral/Packages/DesignSystem/Sources/DesignSystem/Components/PlaceholderThumbnail.swift`
+
+### Verification checklist
+
+- `StoryThumbnail(path:title:baseURL:)` already falls back to `PlaceholderThumbnail` when `path` is nil or empty. No change needed.
+- `CachedAsyncImage` must gracefully handle HTTP 404 from static server (image not seeded yet). Confirm it shows nil/broken image state, not a crash. If it crashes on 404, add a `.onFailure` handler.
+- Confirm `AppConfig.staticBaseURL` ends with `/` so path concatenation is correct.
+
+### Commit message (only if CachedAsyncImage needs fixing)
+```
+[ios] AST-12 guard CachedAsyncImage against 404 with silent failure
+```
+
+---
+
+## Task 7 — Tests
+
+### Backend tests
+
+File: `backend/tests/test_fanfic_thumbnails.py`
+
+```python
+import pytest
+from httpx import AsyncClient
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_returns_valid_path(client: AsyncClient):
+    resp = await client.get("/api/v1/fanfic-thumbnails/random")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "path" in data
+    import re
+    assert re.fullmatch(r"fanfic-thumbnails/([1-9]|[1-4][0-9]|50)\.jpg", data["path"])
+
+@pytest.mark.asyncio
+async def test_random_thumbnail_varies(client: AsyncClient):
+    paths = {(await client.get("/api/v1/fanfic-thumbnails/random")).json()["path"]
+             for _ in range(20)}
+    assert len(paths) >= 3  # probabilistic — 20 draws from 50 must have >= 3 unique
+```
+
+### iOS unit tests
+
+Using the existing test target pattern — mock `APIClient` to return a canned `RandomThumbnailResponse`.
+
+Key test cases:
+1. `fetchFanfics` migration: fanfic with nil path gets `thumbnailPath` set to `"fanfic-thumbnails/3.jpg"`.
+2. `syncActiveJobs`: job status `"complete"` + fanfic with nil path → thumbnail assigned.
+3. Offline (URLError thrown): `thumbnailPath` stays nil, no crash, no error propagated to UI.
+4. `thumbnailPath` already set: neither hook overwrites it.
+
+### Commit message
+```
+[ios][backend] AST-12 add tests for thumbnail endpoint and iOS assignment logic
+```
+
+---
+
+## Execution Order
+
+```
+Task 1  →  Task 2  →  Task 3  →  Task 4  →  Task 5  →  Task 6  →  Task 7
+(backend   (seeding   (iOS DTO   (scrape    (migration  (fallback  (tests)
+ router)    script)    + endpt)   hook)      hook)       audit)
+```
+
+Tasks 1 and 2 can be done in parallel. Tasks 3–5 depend on Task 3 (DTO). Task 7 is last.

--- a/docs/superpowers/plans/2026-04-17-ast12-fanfic-thumbnail-fallback.md
+++ b/docs/superpowers/plans/2026-04-17-ast12-fanfic-thumbnail-fallback.md
@@ -7,6 +7,58 @@
 
 ---
 
+## Task 0a — Audit: `CachedAsyncImage` 404 handling
+
+### Files
+
+- **Read-only audit**: `ios/Astral/Packages/DesignSystem/Sources/DesignSystem/Components/CachedAsyncImage.swift` (or wherever `CachedAsyncImage` is defined — search `DesignSystem` package if path differs)
+
+### Verification
+
+Open the file and confirm:
+- An HTTP 404 response from the static server does **not** crash or hang the view.
+- The component falls through to its failure/placeholder state silently.
+- If `AsyncImage` or a custom `URLSession` fetch is used, check that the `.failure` phase is handled.
+
+### Action
+
+- If 404 is already handled gracefully: no code change, leave a note in the commit message.
+- If 404 causes a crash or uncaught error: add a `.onFailure` / phase-check guard before continuing to Tasks 2–6.
+
+### Commit message (only if fix needed)
+```
+[ios] AST-12 guard CachedAsyncImage against 404 with silent failure
+```
+
+---
+
+## Task 0b — Audit: `AppConfig.staticBaseURL` trailing `/`
+
+### Files
+
+- **Read-only audit**: `ios/Astral/Packages/Core/Sources/Core/AppConfig.swift`
+
+### Verification
+
+Read `AppConfig.swift` and check all three environment branches:
+1. `#if targetEnvironment(simulator)` — `staticBaseURL` should end with `/`
+2. `#else` in `DEBUG` (physical device) — `staticBaseURL` should end with `/`
+3. Release build branch — `staticBaseURL` should end with `/`
+
+A missing trailing slash produces concatenated URLs like `"/staticfanfic-thumbnails/3.jpg"` which 404s.
+
+### Action
+
+- If all three branches already have trailing `/`: no code change.
+- If any branch is missing it: add the trailing `/` and commit.
+
+### Commit message (only if fix needed)
+```
+[ios] AST-12 ensure staticBaseURL has trailing slash in all env branches
+```
+
+---
+
 ## Task 1 — Backend: `GET /api/v1/fanfic-thumbnails/random` endpoint
 
 ### Files
@@ -25,22 +77,38 @@ from pydantic import BaseModel
 FANFIC_THUMBNAIL_COUNT = 50
 
 class RandomThumbnailResponse(BaseModel):
-    path: str
+    path: str  # returned when count=1 or count absent
+
+class RandomThumbnailBatchResponse(BaseModel):
+    paths: list[str]  # returned when count > 1; length == min(count, 50)
 ```
 
 **`backend/app/api/v1/routes/fanfic_thumbnails.py`**
 ```python
 import random
-from fastapi import APIRouter
-from app.schemas.fanfic_thumbnail import RandomThumbnailResponse, FANFIC_THUMBNAIL_COUNT
+from typing import Union
+from fastapi import APIRouter, Query
+from app.schemas.fanfic_thumbnail import (
+    RandomThumbnailResponse,
+    RandomThumbnailBatchResponse,
+    FANFIC_THUMBNAIL_COUNT,
+)
 
 router = APIRouter(prefix="/fanfic-thumbnails", tags=["fanfic-thumbnails"])
 
-@router.get("/random", response_model=RandomThumbnailResponse)
-async def random_fanfic_thumbnail() -> RandomThumbnailResponse:
-    n = random.randint(1, FANFIC_THUMBNAIL_COUNT)
-    return RandomThumbnailResponse(path=f"fanfic-thumbnails/{n}.jpg")
+@router.get("/random")
+async def random_fanfic_thumbnail(
+    count: int = Query(default=1, ge=1, le=FANFIC_THUMBNAIL_COUNT),
+) -> Union[RandomThumbnailResponse, RandomThumbnailBatchResponse]:
+    if count == 1:
+        n = random.randint(1, FANFIC_THUMBNAIL_COUNT)
+        return RandomThumbnailResponse(path=f"fanfic-thumbnails/{n}.jpg")
+    paths = [f"fanfic-thumbnails/{random.randint(1, FANFIC_THUMBNAIL_COUNT)}.jpg"
+             for _ in range(count)]
+    return RandomThumbnailBatchResponse(paths=paths)
 ```
+
+Note: FastAPI's `Query(ge=1, le=50)` enforces the cap server-side — no manual clamping needed. Values > 50 return 422 Unprocessable Entity.
 
 **Add to `backend/app/main.py`** (after existing imports line):
 ```python
@@ -51,16 +119,17 @@ app.include_router(fanfic_thumbnails.router, prefix="/api/v1")
 
 ### Commit message
 ```
-[backend] AST-12 add GET /api/v1/fanfic-thumbnails/random endpoint
+[backend] AST-12 add GET /api/v1/fanfic-thumbnails/random endpoint with ?count=N batch support
 ```
 
 ---
 
-## Task 2 — Backend: image seeding script
+## Task 2 — Backend: image seeding script + Pillow dependency
 
 ### Files
 
 - **New**: `backend/scripts/seed_fanfic_thumbnails.py`
+- **Modify**: `backend/requirements.txt` — add `Pillow>=10.0` if not already present
 
 ### Code
 
@@ -139,9 +208,17 @@ docker compose exec backend python scripts/seed_fanfic_thumbnails.py
 
 **TODO**: Replace generated images with curated manga/book-cover art by dropping real 400×600 JPGs named `1.jpg`–`50.jpg` into the volume and re-running with `--force`.
 
+### Pillow dependency step
+
+Before writing the seeding script, add `Pillow>=10.0` to `backend/requirements.txt`:
+```
+Pillow>=10.0
+```
+Check if it's already present first (`grep -i pillow backend/requirements.txt`). Only add if absent. This is a script-time dependency — the FastAPI app itself does not import Pillow at runtime.
+
 ### Commit message
 ```
-[backend] AST-12 add thumbnail seeding script (50 gradient JPGs)
+[backend] AST-12 add thumbnail seeding script (50 gradient JPGs) and Pillow>=10.0 dep
 ```
 
 ---
@@ -160,6 +237,10 @@ docker compose exec backend python scripts/seed_fanfic_thumbnails.py
 public struct RandomThumbnailResponse: Codable, Sendable {
     public let path: String
 }
+
+public struct RandomThumbnailBatchResponse: Codable, Sendable {
+    public let paths: [String]
+}
 ```
 
 **Endpoints.swift** — add inside `public extension Endpoint` Fanfic section:
@@ -167,11 +248,15 @@ public struct RandomThumbnailResponse: Codable, Sendable {
 static var randomFanficThumbnail: Endpoint {
     Endpoint(path: "/fanfic-thumbnails/random")
 }
+
+static func randomFanficThumbnails(count: Int) -> Endpoint {
+    Endpoint(path: "/fanfic-thumbnails/random?count=\(count)")
+}
 ```
 
 ### Commit message
 ```
-[ios] AST-12 add RandomThumbnailResponse DTO and randomFanficThumbnail endpoint
+[ios] AST-12 add RandomThumbnailResponse/Batch DTOs and randomFanficThumbnail(s) endpoints
 ```
 
 ---
@@ -205,7 +290,7 @@ for job in fanficJobs where job.status == "complete" || job.status == "partial" 
 
 ---
 
-## Task 5 — iOS: migration for existing fanfics
+## Task 5 — iOS: migration for existing fanfics (batch)
 
 ### Files
 
@@ -216,30 +301,36 @@ for job in fanficJobs where job.status == "complete" || job.status == "partial" 
 At the end of the `do` block in `fetchFanfics()`, after `lastSyncTime = .now`:
 
 ```swift
-// AST-12: one-off migration — assign thumbnails to fanfics with nil paths
+// AST-12: one-off migration — assign thumbnails to fanfics with nil paths (batch)
 let nilThumbFanfics = allFanfics.filter { $0.thumbnailPath == nil }
 if !nilThumbFanfics.isEmpty {
+    let count = min(nilThumbFanfics.count, 50)
     AstralLogger.info("Migration: \(nilThumbFanfics.count) fanfics need thumbnails", context: "FanficLibraryVM")
-    for fanfic in nilThumbFanfics {
-        if let dto: RandomThumbnailResponse = try? await APIClient.shared.request(.randomFanficThumbnail) {
-            fanfic.thumbnailPath = dto.path
+    if let batch: RandomThumbnailBatchResponse = try? await APIClient.shared.request(
+        .randomFanficThumbnails(count: count)
+    ) {
+        for (fanfic, path) in zip(nilThumbFanfics, batch.paths) {
+            fanfic.thumbnailPath = path
         }
+        // Fanfics beyond the 50-cap stay nil and are handled on the next library open
+        try? modelContext.save()
+        AstralLogger.info("Migration: thumbnail assignment complete", context: "FanficLibraryVM")
     }
-    try? modelContext.save()
-    AstralLogger.info("Migration: thumbnail assignment complete", context: "FanficLibraryVM")
 }
 ```
 
-Note: `RandomThumbnailResponse` import is available via the `Networking` module already imported in this file.
+**Why batch instead of sequential**: Single HTTP round-trip for up to 50 fanfics. The server returns N distinct (with-replacement) paths in one response. The iOS `zip` assigns one path per fanfic locally. Fanfics beyond 50 are handled on the next `fetchFanfics` call.
+
+Note: `RandomThumbnailBatchResponse` and `randomFanficThumbnails(count:)` are both defined in Task 3 (Networking module already imported in this file).
 
 ### Commit message
 ```
-[ios] AST-12 migrate existing fanfics with nil thumbnailPath on library sync
+[ios] AST-12 migrate existing fanfics with nil thumbnailPath via batch endpoint
 ```
 
 ---
 
-## Task 6 — iOS: fallback handling verification
+## Task 6 — iOS: StoryThumbnail fallback verification
 
 ### Files
 
@@ -249,12 +340,11 @@ Note: `RandomThumbnailResponse` import is available via the `Networking` module 
 ### Verification checklist
 
 - `StoryThumbnail(path:title:baseURL:)` already falls back to `PlaceholderThumbnail` when `path` is nil or empty. No change needed.
-- `CachedAsyncImage` must gracefully handle HTTP 404 from static server (image not seeded yet). Confirm it shows nil/broken image state, not a crash. If it crashes on 404, add a `.onFailure` handler.
-- Confirm `AppConfig.staticBaseURL` ends with `/` so path concatenation is correct.
+- `CachedAsyncImage` 404 handling and `AppConfig.staticBaseURL` trailing-slash checks are covered by Tasks 0a and 0b respectively — do not duplicate them here.
 
-### Commit message (only if CachedAsyncImage needs fixing)
+### Commit message (only if StoryThumbnail needs fixing)
 ```
-[ios] AST-12 guard CachedAsyncImage against 404 with silent failure
+[ios] AST-12 fix StoryThumbnail fallback to PlaceholderThumbnail for nil/empty path
 ```
 
 ---
@@ -305,9 +395,17 @@ Key test cases:
 ## Execution Order
 
 ```
-Task 1  →  Task 2  →  Task 3  →  Task 4  →  Task 5  →  Task 6  →  Task 7
-(backend   (seeding   (iOS DTO   (scrape    (migration  (fallback  (tests)
- router)    script)    + endpt)   hook)      hook)       audit)
+Task 0a  →  Task 0b  →  Task 1  ┐
+(CachedAsync   (AppConfig      (backend    ├──parallel──→  Task 3  →  Task 4  →  Task 5  →  Task 6  →  Task 7
+ 404 audit)     slash audit)    router)    │              (iOS DTO   (scrape    (migration  (Story     (tests)
+                                Task 2  ──┘               + endpt)   hook)      hook-batch) Thumbnail
+                               (seeding                                                      audit)
+                                script +
+                                Pillow dep)
 ```
 
-Tasks 1 and 2 can be done in parallel. Tasks 3–5 depend on Task 3 (DTO). Task 7 is last.
+- Tasks 0a and 0b are read-only audits — must run first to catch blockers before any code is written.
+- Tasks 1 and 2 can run in parallel after audits pass.
+- Task 3 (iOS DTO + endpoint) must complete before Tasks 4, 5, and 6.
+- Tasks 4, 5, 6 can be parallelized after Task 3.
+- Task 7 (tests) is last.

--- a/docs/superpowers/plans/2026-04-17-landing-animation-redesign.md
+++ b/docs/superpowers/plans/2026-04-17-landing-animation-redesign.md
@@ -1,0 +1,1393 @@
+# Landing Animation Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rewrite the Astral landing animation to fix orb overlap, remove DispatchQueue sequencing, honor `accessibilityReduceMotion`, and add five polish touches — all in one bundled refactor.
+
+**Architecture:** Single-file change to `ios/Astral/App/RootView.swift`. `MorphLandingView` keeps its shape and final visuals; `runAnimation()` is rewritten to use `withAnimation(...) completion:` chaining (iOS 17+) instead of `DispatchQueue.main.asyncAfter`. A cancellation token guards late completions. A local `PhaseAnimator` inside each orb view drives Phase 2 wobble without touching the phase-chain parent.
+
+**Tech Stack:** SwiftUI (iOS 17.2+), Swift 6, Xcode project via XcodeGen, DesignSystem package (`PressButtonStyle`, `AstralAnimation`).
+
+**Reference spec:** [docs/superpowers/specs/2026-04-17-landing-animation-redesign-design.md](../specs/2026-04-17-landing-animation-redesign-design.md)
+
+**Linear:** parent [AST-1](https://linear.app/nnetraganti/issue/AST-1); closes [AST-2](https://linear.app/nnetraganti/issue/AST-2), [AST-3](https://linear.app/nnetraganti/issue/AST-3), [AST-4](https://linear.app/nnetraganti/issue/AST-4), [AST-5](https://linear.app/nnetraganti/issue/AST-5).
+
+**Branch:** `feature/ast-1-landing-animation-redesign` (branched from `development`).
+
+---
+
+## Testing Approach
+
+This is a visual animation refactor. There is no unit-test harness for `RootView.swift` and the behavior being changed is not pure logic — it's motion + layout observed on screen. **Classic TDD does not apply.** Each task instead has:
+
+1. A concrete code change.
+2. A build check: `cd ios/Astral && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build`
+3. A simulator run with explicit pass/fail criteria (what you should see).
+4. A commit.
+
+The existing `--uitesting` launch arg sets `showLanding = false`, so automated UI tests bypass the landing view and are unaffected by these changes.
+
+---
+
+## Task 0: Branch Setup
+
+**Files:** none (git operation only)
+
+- [ ] **Step 1: Confirm you are on `development` and clean**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git status
+git branch --show-current
+```
+
+Expected: current branch is `development`. If there are unstaged changes unrelated to this work (`CLAUDE.md`, `project.pbxproj`, etc.), leave them — you will not stage them. If you are on another branch, `git checkout development` first.
+
+- [ ] **Step 2: Create the feature branch**
+
+```bash
+git checkout -b feature/ast-1-landing-animation-redesign
+```
+
+- [ ] **Step 3: Verify build from a clean slate**
+
+```bash
+cd ios/Astral && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -20
+```
+
+Expected: `** BUILD SUCCEEDED **`. If it fails for a reason unrelated to this plan (e.g. simulator ID missing), swap the destination for any available iOS 17.2+ simulator: `xcrun simctl list devices available | grep iPhone`.
+
+No commit for this task.
+
+---
+
+## Task 1: Add New State & Environment — Scaffolding Only
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Add the new `@State` vars and `@Environment` the spec requires. Split `contentReveal` into `contentRevealGold` / `contentRevealBlue`. **No behavioral change yet** — both new vars animate identically for now.
+
+- [ ] **Step 1: Add `accessibilityReduceMotion` environment and new state**
+
+In `RootView.swift`, inside `private struct MorphLandingView`, just after `let onSelect: (AppTab) -> Void` (line 44), add:
+
+```swift
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+```
+
+Then replace the block declaring `contentReveal` and `contentSlide` (currently lines 70–72):
+
+```swift
+    // Content inside orbs
+    @State private var contentReveal: Double = 0
+    @State private var contentSlide: CGFloat = 20 // internal content slides up
+```
+
+with:
+
+```swift
+    // Content inside orbs
+    @State private var contentRevealGold: Double = 0
+    @State private var contentRevealBlue: Double = 0
+    @State private var contentSlide: CGFloat = 20 // internal content slides up
+```
+
+Just below the title/labels block (after `@State private var labelOpacity: Double = 0`, currently line 78), add:
+
+```swift
+    @State private var titleBlur: CGFloat = 8
+
+    // Cancellation guard for phase completion chain
+    @State private var animationToken = UUID()
+```
+
+- [ ] **Step 2: Update `goldOrb` to use `contentRevealGold`**
+
+In `goldOrb` (the `VStack` block starting at line 191), find:
+
+```swift
+            .offset(y: contentSlide)
+            .opacity(contentReveal)
+            .clipShape(RoundedRectangle(cornerRadius: goldCornerRadius))
+```
+
+Change `.opacity(contentReveal)` to `.opacity(contentRevealGold)`.
+
+- [ ] **Step 3: Update `blueOrb` to use `contentRevealBlue`**
+
+In `blueOrb` (the `VStack` block starting at line 243), find:
+
+```swift
+            .offset(y: contentSlide)
+            .opacity(contentReveal)
+            .clipShape(RoundedRectangle(cornerRadius: blueCornerRadius))
+```
+
+Change `.opacity(contentReveal)` to `.opacity(contentRevealBlue)`.
+
+- [ ] **Step 4: Update `runAnimation()` content-reveal write to use both new vars**
+
+In `runAnimation()`, find the Phase 2 content reveal block (currently around line 334):
+
+```swift
+            // Content fades in and slides up
+            withAnimation(.easeOut(duration: 1.0).delay(0.3)) {
+                contentReveal = 0.85
+                contentSlide = 0
+            }
+```
+
+Replace the body of the `withAnimation` block so both new vars get 0.85:
+
+```swift
+            // Content fades in and slides up
+            withAnimation(.easeOut(duration: 1.0).delay(0.3)) {
+                contentRevealGold = 0.85
+                contentRevealBlue = 0.85
+                contentSlide = 0
+            }
+```
+
+Then find the Phase 3 content dissolve block (currently around line 358):
+
+```swift
+            // Content dissolves
+            withAnimation(.easeIn(duration: 0.4)) {
+                contentReveal = 1.0 // icon stays, decorative lines will be clipped
+                contentSlide = -5
+            }
+```
+
+Replace the body so both new vars get 1.0:
+
+```swift
+            // Content dissolves
+            withAnimation(.easeIn(duration: 0.4)) {
+                contentRevealGold = 1.0 // icon stays, decorative lines will be clipped
+                contentRevealBlue = 1.0
+                contentSlide = -5
+            }
+```
+
+- [ ] **Step 5: Attach title blur modifier (still animated to 0 later, but already declared)**
+
+In the title `VStack` (starting at line 105), find `Text("Astral")` and its modifiers:
+
+```swift
+                Text("Astral")
+                    .font(.system(size: 42, weight: .heavy, design: .rounded))
+                    .foregroundStyle(AstralColors.white)
+                    .scaleEffect(titleScale)
+                    .opacity(titleOpacity)
+```
+
+Add `.blur(radius: titleBlur)` between `.foregroundStyle(...)` and `.scaleEffect(...)`:
+
+```swift
+                Text("Astral")
+                    .font(.system(size: 42, weight: .heavy, design: .rounded))
+                    .foregroundStyle(AstralColors.white)
+                    .blur(radius: titleBlur)
+                    .scaleEffect(titleScale)
+                    .opacity(titleOpacity)
+```
+
+The title starts with `titleBlur = 8` AND `titleOpacity = 0`, so the blur is invisible until opacity rises — a later task animates blur to 0.
+
+- [ ] **Step 6: Add `onDisappear` token refresh**
+
+At the bottom of the `GeometryReader`'s `ZStack` (currently right after the `onAppear { ... }` block, around line 166), add:
+
+```swift
+        .onDisappear {
+            animationToken = UUID()
+        }
+```
+
+Final structure should look like:
+
+```swift
+        .onAppear {
+            screenSize = geo.size
+            // Start orbs at absolute screen corners
+            goldOffset = CGSize(width: -(geo.size.width / 2 - 20), height: -(geo.size.height / 3))
+            blueOffset = CGSize(width: geo.size.width / 2 - 20, height: geo.size.height / 3)
+            runAnimation()
+        }
+        .onDisappear {
+            animationToken = UUID()
+        }
+        } // GeometryReader
+    }
+```
+
+- [ ] **Step 7: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 8: Simulator smoke check (no behavior change yet)**
+
+Open `ios/Astral/Astral.xcodeproj`, run on an iOS 17.2+ simulator. Launch app. The animation should play **exactly as before** (still uses DispatchQueue — not fixed yet). No new visuals, no regressions.
+
+Pass criteria: animation sequence completes, orbs reach final resting position, labels/subtitle appear, taps work.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-1 add reduce-motion env + split content-reveal state
+
+Scaffolding for landing animation redesign. No behavioral change —
+contentRevealGold/Blue animate together for now. titleBlur attached
+but still animated by later phase blocks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Split `runAnimation()` Into Phase Functions (Pure Refactor)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Extract each phase into its own method. Still uses `DispatchQueue.main.asyncAfter` for now — this task is a mechanical refactor to make Task 3 simpler to review.
+
+- [ ] **Step 1: Replace the `runAnimation()` body**
+
+Replace the entire `private func runAnimation() { ... }` (currently lines 269–404) with:
+
+```swift
+    // MARK: - Animation Sequence
+
+    private func runAnimation() {
+        // Ambient background — continuous slow drift
+        withAnimation(.easeInOut(duration: 5.0).repeatForever(autoreverses: true)) {
+            ambientShift = true
+        }
+
+        runPhase1()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { runPhase2() }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) { runPhase2MidDrift() }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.8) { runPhase3() }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.8) { runPhase4() }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.2) { phase = 4 }
+    }
+
+    // PHASE 1: Blob Appear (0.3s–1.0s) — tiny shapes pop in far from center
+    private func runPhase1() {
+        let halfW = screenSize.width / 2
+        let halfH = screenSize.height / 3
+
+        withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+            goldOpacity = 1
+            goldSize = 30
+            goldBlobSkew = 1.3
+            goldGlow = 0.5
+        }
+
+        withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+            blueOpacity = 1
+            blueSize = 24
+            blueBlobSkew = 0.8
+            blueGlow = 0.5
+        }
+
+        withAnimation(.easeInOut(duration: 1.2).delay(0.5)) {
+            goldOffset = CGSize(width: -(halfW * 0.45), height: -(halfH * 0.5))
+            blueOffset = CGSize(width: halfW * 0.4, height: halfH * 0.45)
+            goldRotation = -18
+            blueRotation = 12
+        }
+    }
+
+    // PHASE 2: Expand + Drift (1.0s–2.8s) — orbs grow, content fades in
+    private func runPhase2() {
+        let halfW = screenSize.width / 2
+        let halfH = screenSize.height / 3
+        phase = 2
+
+        withAnimation(.spring(response: 0.9, dampingFraction: 0.7)) {
+            goldSize = 140
+            blueSize = 135
+            goldBlobSkew = 1.0
+            blueBlobSkew = 1.0
+            goldGlow = 0.7
+            blueGlow = 0.7
+        }
+
+        withAnimation(.easeInOut(duration: 1.5)) {
+            goldOffset = CGSize(width: -(halfW * 0.3), height: -(halfH * 0.2))
+            blueOffset = CGSize(width: halfW * 0.25, height: halfH * 0.2)
+            goldRotation = -8
+            blueRotation = 6
+        }
+
+        withAnimation(.easeOut(duration: 1.0).delay(0.3)) {
+            contentRevealGold = 0.85
+            contentRevealBlue = 0.85
+            contentSlide = 0
+        }
+    }
+
+    // Mid-drift — floating motion, pulling gradually closer (TO BE REMOVED in Task 4)
+    private func runPhase2MidDrift() {
+        let halfW = screenSize.width / 2
+        let halfH = screenSize.height / 3
+
+        withAnimation(.easeInOut(duration: 1.0)) {
+            goldOffset = CGSize(width: -(halfW * 0.2), height: -(halfH * 0.1))
+            blueOffset = CGSize(width: halfW * 0.15, height: halfH * 0.12)
+            goldRotation = -4
+            blueRotation = 3
+        }
+    }
+
+    // PHASE 3: Contract + Morph (2.8s–3.8s) — pull inward, shape morphs
+    private func runPhase3() {
+        phase = 3
+
+        withAnimation(.easeIn(duration: 0.4)) {
+            contentRevealGold = 1.0
+            contentRevealBlue = 1.0
+            contentSlide = -5
+        }
+
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.55, blendDuration: 0.3)) {
+            goldSize = 120
+            blueSize = 120
+            goldCornerRadius = 28
+            blueCornerRadius = 28
+            goldOffset = CGSize(width: -80, height: 30)
+            blueOffset = CGSize(width: 80, height: 30)
+            goldRotation = 0
+            blueRotation = 0
+            goldGlow = 0.3
+            blueGlow = 0.3
+        }
+
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.65).delay(0.2)) {
+            titleScale = 1.0
+            titleOpacity = 1
+        }
+    }
+
+    // PHASE 4: Ready (3.8s–4.5s) — labels appear, buttons tappable
+    private func runPhase4() {
+        withAnimation(.easeOut(duration: 0.5)) {
+            subtitleOpacity = 1
+        }
+        withAnimation(.easeOut(duration: 0.4).delay(0.15)) {
+            labelOpacity = 1
+        }
+    }
+}
+```
+
+Note: the closing `}` above is the `MorphLandingView` struct close — keep one blank line before `#Preview`.
+
+- [ ] **Step 2: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Simulator smoke check**
+
+Run in simulator. Animation should still play identically to before. This is a pure mechanical refactor.
+
+Pass criteria: no visible change from Task 1.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-1 extract runAnimation phases into per-phase functions
+
+Pure refactor — still uses DispatchQueue.main.asyncAfter. Sets up
+Task 3 to swap sequencing for withAnimation completion chaining
+without a massive diff.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Replace DispatchQueue With Completion Chaining (AST-3)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Remove all `DispatchQueue.main.asyncAfter` calls. Drive phase transitions via `withAnimation(_:_:completionCriteria:completion:)`. The "driver" of each phase is the longest-running `withAnimation` and carries the completion handler.
+
+- [ ] **Step 1: Rewrite `runAnimation()` to chain via completion handlers**
+
+Replace the `runAnimation()` method (the one written in Task 2) with:
+
+```swift
+    private func runAnimation() {
+        // Ambient background — continuous slow drift
+        withAnimation(.easeInOut(duration: 5.0).repeatForever(autoreverses: true)) {
+            ambientShift = true
+        }
+
+        runPhase1()
+    }
+```
+
+- [ ] **Step 2: Update `runPhase1()` to chain Phase 2 via completion**
+
+Replace `runPhase1()` with:
+
+```swift
+    private func runPhase1() {
+        let halfW = screenSize.width / 2
+        let halfH = screenSize.height / 3
+        let token = animationToken
+
+        withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+            goldOpacity = 1
+            goldSize = 30
+            goldBlobSkew = 1.3
+            goldGlow = 0.5
+        }
+
+        withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+            blueOpacity = 1
+            blueSize = 24
+            blueBlobSkew = 0.8
+            blueGlow = 0.5
+        }
+
+        // Driver — longest (0.5 + 1.2 = 1.7s). Carries completion.
+        withAnimation(.easeInOut(duration: 1.2).delay(0.5),
+                      completionCriteria: .logicallyComplete) {
+            goldOffset = CGSize(width: -(halfW * 0.45), height: -(halfH * 0.5))
+            blueOffset = CGSize(width: halfW * 0.4, height: halfH * 0.45)
+            goldRotation = -18
+            blueRotation = 12
+        } completion: {
+            guard token == animationToken else { return }
+            runPhase2()
+        }
+    }
+```
+
+- [ ] **Step 3: Update `runPhase2()` to chain Phase 2 mid-drift (kept for now) via completion**
+
+Replace `runPhase2()` and `runPhase2MidDrift()` with:
+
+```swift
+    private func runPhase2() {
+        let halfW = screenSize.width / 2
+        let halfH = screenSize.height / 3
+        let token = animationToken
+        phase = 2
+
+        withAnimation(.spring(response: 0.9, dampingFraction: 0.7)) {
+            goldSize = 140
+            blueSize = 135
+            goldBlobSkew = 1.0
+            blueBlobSkew = 1.0
+            goldGlow = 0.7
+            blueGlow = 0.7
+        }
+
+        withAnimation(.easeOut(duration: 1.0).delay(0.3)) {
+            contentRevealGold = 0.85
+            contentRevealBlue = 0.85
+            contentSlide = 0
+        }
+
+        // Driver — longest positional drift (1.5s). Chains into mid-drift.
+        withAnimation(.easeInOut(duration: 1.5),
+                      completionCriteria: .logicallyComplete) {
+            goldOffset = CGSize(width: -(halfW * 0.3), height: -(halfH * 0.2))
+            blueOffset = CGSize(width: halfW * 0.25, height: halfH * 0.2)
+            goldRotation = -8
+            blueRotation = 6
+        } completion: {
+            guard token == animationToken else { return }
+            runPhase2MidDrift()
+        }
+    }
+
+    private func runPhase2MidDrift() {
+        let halfW = screenSize.width / 2
+        let halfH = screenSize.height / 3
+        let token = animationToken
+
+        // Driver — 1.0s. Chains into Phase 3.
+        withAnimation(.easeInOut(duration: 1.0),
+                      completionCriteria: .logicallyComplete) {
+            goldOffset = CGSize(width: -(halfW * 0.2), height: -(halfH * 0.1))
+            blueOffset = CGSize(width: halfW * 0.15, height: halfH * 0.12)
+            goldRotation = -4
+            blueRotation = 3
+        } completion: {
+            guard token == animationToken else { return }
+            runPhase3()
+        }
+    }
+```
+
+- [ ] **Step 4: Update `runPhase3()` to chain Phase 4 via completion**
+
+Replace `runPhase3()` with:
+
+```swift
+    private func runPhase3() {
+        let token = animationToken
+        phase = 3
+
+        withAnimation(.easeIn(duration: 0.4)) {
+            contentRevealGold = 1.0
+            contentRevealBlue = 1.0
+            contentSlide = -5
+        }
+
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.65).delay(0.2)) {
+            titleScale = 1.0
+            titleOpacity = 1
+        }
+
+        // Driver — morph spring. Carries completion into Phase 4.
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.55, blendDuration: 0.3),
+                      completionCriteria: .logicallyComplete) {
+            goldSize = 120
+            blueSize = 120
+            goldCornerRadius = 28
+            blueCornerRadius = 28
+            goldOffset = CGSize(width: -80, height: 30)
+            blueOffset = CGSize(width: 80, height: 30)
+            goldRotation = 0
+            blueRotation = 0
+            goldGlow = 0.3
+            blueGlow = 0.3
+        } completion: {
+            guard token == animationToken else { return }
+            runPhase4()
+        }
+    }
+```
+
+- [ ] **Step 5: Update `runPhase4()` to finalize `phase = 4`**
+
+Replace `runPhase4()` with:
+
+```swift
+    private func runPhase4() {
+        let token = animationToken
+
+        withAnimation(.easeOut(duration: 0.5)) {
+            subtitleOpacity = 1
+        }
+
+        // Driver — labels are last. Flips phase to 4 when done.
+        withAnimation(.easeOut(duration: 0.4).delay(0.15),
+                      completionCriteria: .logicallyComplete) {
+            labelOpacity = 1
+        } completion: {
+            guard token == animationToken else { return }
+            phase = 4
+        }
+    }
+```
+
+- [ ] **Step 6: Verify NO `DispatchQueue` remains in `RootView.swift`**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+grep -n DispatchQueue ios/Astral/App/RootView.swift
+```
+
+Expected: no output (grep returns nothing). If any remain, remove them.
+
+- [ ] **Step 7: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 8: Simulator check**
+
+Run. Because completion chaining triggers the next phase as soon as the driver's animation logically completes (slightly different from the hardcoded 1.0s / 1.8s / 2.8s / 3.8s timestamps), phases may flow slightly faster or slower — the **ordering** is what matters.
+
+Pass criteria:
+- Full sequence plays from blank → orbs appear → expand → morph → labels.
+- `phase = 4` is reached and taps become active (tap either zone, app switches to Comic or Fanfic tab).
+- No hangs, no frozen orbs.
+- Orb overlap still exists (Task 4 fixes that).
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-3 replace DispatchQueue with withAnimation completion chain
+
+Each phase's driver animation carries completionCriteria:.logicallyComplete
+and triggers the next runPhase* function. animationToken guards against
+completions firing after the view disappears.
+
+Closes AST-3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Fix Phase 2 Overlap — Delete Mid-Drift & Widen Positions (AST-2)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Remove `runPhase2MidDrift()` entirely. Widen Phase 2 positions to `±halfW * 0.38`. Phase 2 now chains directly to Phase 3 on driver completion.
+
+- [ ] **Step 1: Delete `runPhase2MidDrift()`**
+
+Delete the entire `runPhase2MidDrift()` method written in Task 3 (the whole function).
+
+- [ ] **Step 2: Rewrite `runPhase2()` with wider positions and direct chain to Phase 3**
+
+Replace `runPhase2()` with:
+
+```swift
+    private func runPhase2() {
+        let halfW = screenSize.width / 2
+        let halfH = screenSize.height / 3
+        let token = animationToken
+        phase = 2
+
+        withAnimation(.spring(response: 0.9, dampingFraction: 0.7)) {
+            goldSize = 140
+            blueSize = 135
+            goldBlobSkew = 1.0
+            blueBlobSkew = 1.0
+            goldGlow = 0.7
+            blueGlow = 0.7
+        }
+
+        withAnimation(.easeOut(duration: 1.0).delay(0.3)) {
+            contentRevealGold = 0.85
+            contentRevealBlue = 0.85
+            contentSlide = 0
+        }
+
+        // Positions kept wider — centers ≥148pt apart on a 390pt screen,
+        // clearing 140pt orbs. Replaces the old two-step drift that
+        // pulled orbs to ~68pt center distance (AST-2).
+        // Driver — longest (1.5s). Chains into Phase 3.
+        withAnimation(.easeInOut(duration: 1.5),
+                      completionCriteria: .logicallyComplete) {
+            goldOffset = CGSize(width: -(halfW * 0.38), height: -(halfH * 0.2))
+            blueOffset = CGSize(width: halfW * 0.38, height: halfH * 0.2)
+            goldRotation = -8
+            blueRotation = 6
+        } completion: {
+            guard token == animationToken else { return }
+            runPhase3()
+        }
+    }
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Simulator check — verify no orb overlap**
+
+Run on at least two simulator sizes:
+- iPhone 15 (393pt wide)
+- iPhone SE 3rd gen (375pt wide) — narrowest supported
+
+Watch the animation through Phase 2. Orbs should grow to ~140pt but never visually touch. Slowdown is available via Xcode → Debug → Simulator → Slow Animations (⌘T) to confirm by eye.
+
+Pass criteria:
+- No visible orb collision at any point in Phases 1, 2, or 3.
+- Phase 3 still lands at `(-80, 30)` / `(80, 30)` with 160pt center separation.
+- If orbs visibly clip on iPhone SE, stop and report. Fallback (not applied yet): cap `goldSize`/`blueSize` at 130pt in Phase 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-2 fix Phase 2 orb overlap
+
+Delete the 1.8s mid-drift block that pulled 140pt orbs to 68pt
+center distance (72pt visual overlap). Widen Phase 2 positions
+to ±halfW * 0.38 so centers stay ≥148pt apart on a 390pt screen.
+Phase 2 now chains directly to Phase 3.
+
+Closes AST-2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Reduce Motion Support (AST-4)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Guard `runAnimation()` with a reduce-motion branch that snaps to the final state and cross-fades opacity.
+
+- [ ] **Step 1: Update `runAnimation()` to guard on `reduceMotion`**
+
+Replace `runAnimation()` with:
+
+```swift
+    private func runAnimation() {
+        if reduceMotion {
+            applyReducedMotionState()
+            return
+        }
+
+        // Ambient background — continuous slow drift
+        withAnimation(.easeInOut(duration: 5.0).repeatForever(autoreverses: true)) {
+            ambientShift = true
+        }
+
+        runPhase1()
+    }
+
+    private func applyReducedMotionState() {
+        // Snap all state vars to Phase 4 final values (no motion).
+        goldSize = 120
+        blueSize = 120
+        goldOffset = CGSize(width: -80, height: 30)
+        blueOffset = CGSize(width: 80, height: 30)
+        goldRotation = 0
+        blueRotation = 0
+        goldBlobSkew = 1.0
+        blueBlobSkew = 1.0
+        goldCornerRadius = 28
+        blueCornerRadius = 28
+        goldGlow = 0.3
+        blueGlow = 0.3
+        contentRevealGold = 1.0
+        contentRevealBlue = 1.0
+        contentSlide = -5
+        titleScale = 1.0
+        titleBlur = 0
+
+        // Single cross-fade for opacity values — no positional motion, no ambient drift.
+        withAnimation(.easeOut(duration: 0.3)) {
+            goldOpacity = 1
+            blueOpacity = 1
+            titleOpacity = 1
+            subtitleOpacity = 1
+            labelOpacity = 1
+        }
+        phase = 4
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Simulator check — Reduce Motion ON**
+
+In simulator: Settings → Accessibility → Motion → Reduce Motion → ON.
+
+Force-quit and relaunch Astral. The landing screen should:
+- Show orbs already at final positions (bottom pair, `±80, 30`).
+- Cross-fade all opacity over ~0.3s.
+- Title "Astral" visible at full scale with no blur.
+- Taps active immediately (no 4.2s wait).
+- No ambient background drift.
+
+- [ ] **Step 4: Simulator check — Reduce Motion OFF**
+
+Turn Reduce Motion OFF and relaunch. Full animation sequence should play as in Task 4.
+
+Pass criteria: both modes work; taps land in the correct tab.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-4 honor accessibilityReduceMotion on landing
+
+When Reduce Motion is on, snap orbs to final state and cross-fade
+opacity over 0.3s. Skip ambient drift entirely.
+
+Closes AST-4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Stagger Content Reveal (AST-5 #1)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Gold content reveals 0.15s before blue during Phase 2.
+
+- [ ] **Step 1: Split the Phase 2 content-reveal `withAnimation` into two**
+
+In `runPhase2()`, find the content-reveal block:
+
+```swift
+        withAnimation(.easeOut(duration: 1.0).delay(0.3)) {
+            contentRevealGold = 0.85
+            contentRevealBlue = 0.85
+            contentSlide = 0
+        }
+```
+
+Replace with two separate animations for the fades, and animate `contentSlide` with the gold one (so slide happens once, tied to first reveal):
+
+```swift
+        // Stagger: gold reveals first, blue 0.15s later.
+        withAnimation(.easeOut(duration: 1.0).delay(0.3)) {
+            contentRevealGold = 0.85
+            contentSlide = 0
+        }
+        withAnimation(.easeOut(duration: 1.0).delay(0.45)) {
+            contentRevealBlue = 0.85
+        }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Simulator check**
+
+Run with Reduce Motion OFF. Watch Phase 2 closely (Slow Animations helps). Gold orb's internal content (book icon + manga panels) should start fading in noticeably before the blue orb's content (scroll icon + text lines).
+
+Pass criteria: visible offset between gold and blue content reveals.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-5 stagger content reveal between orbs
+
+Gold content fades in at delay 0.3s; blue follows at 0.45s. Adds
+rhythm to what was a simultaneous cross-fade.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Bouncy Phase 3 Finale (AST-5 #3)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Swap Phase 3 morph spring for `.bouncy(duration: 0.5, extraBounce: 0.15)`.
+
+- [ ] **Step 1: Update the Phase 3 morph driver animation**
+
+In `runPhase3()`, find the driver `withAnimation`:
+
+```swift
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.55, blendDuration: 0.3),
+                      completionCriteria: .logicallyComplete) {
+```
+
+Replace with:
+
+```swift
+        withAnimation(.bouncy(duration: 0.5, extraBounce: 0.15),
+                      completionCriteria: .logicallyComplete) {
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Simulator check**
+
+Watch Phase 3 — when orbs contract and morph into rounded rectangles, they should "snap" into place with a satisfying bounce. Less random flop than the previous low-damping spring.
+
+Pass criteria: settle motion feels intentional, not janky.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-5 use .bouncy spring for Phase 3 morph finale"
+```
+
+---
+
+## Task 8: Title Blur-In (AST-5 #4)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Animate `titleBlur: 8 → 0` alongside the title scale/opacity in Phase 3.
+
+- [ ] **Step 1: Update the Phase 3 title `withAnimation`**
+
+In `runPhase3()`, find:
+
+```swift
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.65).delay(0.2)) {
+            titleScale = 1.0
+            titleOpacity = 1
+        }
+```
+
+Replace with:
+
+```swift
+        withAnimation(.spring(response: 0.6, dampingFraction: 0.65).delay(0.2)) {
+            titleScale = 1.0
+            titleOpacity = 1
+            titleBlur = 0
+        }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Simulator check**
+
+Watch title appear at start of Phase 3. "Astral" should resolve from blurry to sharp as it scales up and fades in.
+
+Pass criteria: title has a visible blur-to-sharp focus transition (not just a plain fade-in).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-5 blur-in the 'Astral' title during Phase 3"
+```
+
+---
+
+## Task 9: Press Feedback on Tap Zones (AST-5 #5)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Swap `Color.clear.onTapGesture` for `Button` with `PressButtonStyle` (`.pressEffect()` from `DesignSystem`). Keep accessibility identifiers.
+
+- [ ] **Step 1: Rewrite the tap-zone `HStack`**
+
+In `body`, find the tap-zones block (currently):
+
+```swift
+            // Tap zones — only active in phase 4
+            if phase >= 4 {
+                HStack(spacing: 0) {
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture { onSelect(.comic) }
+                        .accessibilityIdentifier(AccessibilityID.landingComicOrb)
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture { onSelect(.fanfic) }
+                        .accessibilityIdentifier(AccessibilityID.landingFanficOrb)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+```
+
+Replace with:
+
+```swift
+            // Tap zones — only active in phase 4
+            if phase >= 4 {
+                HStack(spacing: 0) {
+                    Button {
+                        onSelect(.comic)
+                    } label: {
+                        Color.clear
+                            .contentShape(Rectangle())
+                    }
+                    .pressEffect()
+                    .accessibilityIdentifier(AccessibilityID.landingComicOrb)
+
+                    Button {
+                        onSelect(.fanfic)
+                    } label: {
+                        Color.clear
+                            .contentShape(Rectangle())
+                    }
+                    .pressEffect()
+                    .accessibilityIdentifier(AccessibilityID.landingFanficOrb)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+```
+
+Note: `.pressEffect()` is defined in the `DesignSystem` package (already imported at the top of `RootView.swift`).
+
+- [ ] **Step 2: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Simulator check**
+
+Let the animation complete to Phase 4. Tap-and-hold the left half (comic) — the entire left zone should scale down ~4% and fade slightly. Release — returns to full size, navigates to comic tab. Same for the right half (fanfic).
+
+Pass criteria: both zones have the tactile press feedback; tap still dismisses landing into the correct tab.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-5 add press feedback to landing tap zones
+
+Replace Color.clear.onTapGesture with Button + .pressEffect() so
+the tap zones scale + fade on press, matching interactive feel
+elsewhere in the app.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Phase 2 Wobble (AST-5 #2)
+
+**Files:**
+- Modify: `ios/Astral/App/RootView.swift`
+
+Wrap the orb shape stacks in a local `PhaseAnimator` keyed on `phase == 2`. A single run cycles 0° → -5° → +5° → 0°. Blue is offset 0.15s from gold.
+
+- [ ] **Step 1: Add a wobble helper enum at the file level**
+
+At the top of `RootView.swift`, just below `import FanficFeature`, add:
+
+```swift
+// Three-beat wobble cycle used by orbs during Phase 2 expansion.
+private enum WobbleBeat: CaseIterable {
+    case rest, left, right, settle
+    var angle: Double {
+        switch self {
+        case .rest: return 0
+        case .left: return -5
+        case .right: return 5
+        case .settle: return 0
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Wrap `goldOrb` with PhaseAnimator**
+
+Replace the `goldOrb` computed property with:
+
+```swift
+    private var goldOrb: some View {
+        PhaseAnimator(WobbleBeat.allCases, trigger: phase == 2) { beat in
+            goldOrbBody
+                .rotationEffect(.degrees(beat.angle))
+        } animation: { _ in
+            .easeInOut(duration: 0.7)
+        }
+    }
+
+    private var goldOrbBody: some View {
+        ZStack {
+            // Glow halo
+            RoundedRectangle(cornerRadius: goldCornerRadius)
+                .fill(goldColor.opacity(0.15))
+                .frame(width: 130 * goldBlobSkew, height: 130)
+                .blur(radius: 20)
+                .opacity(goldGlow)
+
+            // Main shape
+            RoundedRectangle(cornerRadius: goldCornerRadius)
+                .fill(goldColor.opacity(0.15))
+                .frame(width: 130 * goldBlobSkew, height: 130)
+
+            RoundedRectangle(cornerRadius: goldCornerRadius)
+                .stroke(goldColor.opacity(0.35), lineWidth: 2)
+                .frame(width: 130 * goldBlobSkew, height: 130)
+
+            // Content inside — manga panel grid + book icon
+            VStack(spacing: 5) {
+                Image(systemName: "book.fill")
+                    .font(.system(size: 32, weight: .medium))
+                    .foregroundStyle(goldColor.opacity(0.8))
+
+                VStack(spacing: 2) {
+                    HStack(spacing: 2) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(goldColor.opacity(0.2))
+                            .frame(width: 24, height: 12)
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(goldColor.opacity(0.15))
+                            .frame(width: 18, height: 12)
+                    }
+                    HStack(spacing: 2) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(goldColor.opacity(0.15))
+                            .frame(width: 14, height: 10)
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(goldColor.opacity(0.2))
+                            .frame(width: 28, height: 10)
+                    }
+                }
+            }
+            .offset(y: contentSlide)
+            .opacity(contentRevealGold)
+            .clipShape(RoundedRectangle(cornerRadius: goldCornerRadius))
+        }
+    }
+```
+
+- [ ] **Step 3: Wrap `blueOrb` with PhaseAnimator (with 0.15s delay)**
+
+Replace the `blueOrb` computed property with:
+
+```swift
+    private var blueOrb: some View {
+        PhaseAnimator(WobbleBeat.allCases, trigger: phase == 2) { beat in
+            blueOrbBody
+                .rotationEffect(.degrees(beat.angle))
+        } animation: { _ in
+            .easeInOut(duration: 0.7).delay(0.15)
+        }
+    }
+
+    private var blueOrbBody: some View {
+        ZStack {
+            // Glow halo
+            RoundedRectangle(cornerRadius: blueCornerRadius)
+                .fill(blueColor.opacity(0.15))
+                .frame(width: 130 * blueBlobSkew, height: 130)
+                .blur(radius: 20)
+                .opacity(blueGlow)
+
+            // Main shape
+            RoundedRectangle(cornerRadius: blueCornerRadius)
+                .fill(blueColor.opacity(0.15))
+                .frame(width: 130 * blueBlobSkew, height: 130)
+
+            RoundedRectangle(cornerRadius: blueCornerRadius)
+                .stroke(blueColor.opacity(0.35), lineWidth: 2)
+                .frame(width: 130 * blueBlobSkew, height: 130)
+
+            // Content inside — text lines + scroll icon
+            VStack(spacing: 5) {
+                Image(systemName: "scroll.fill")
+                    .font(.system(size: 30, weight: .medium))
+                    .foregroundStyle(blueColor.opacity(0.8))
+
+                VStack(spacing: 3) {
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(blueColor.opacity(0.25))
+                        .frame(width: 40, height: 3)
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(blueColor.opacity(0.18))
+                        .frame(width: 32, height: 3)
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(blueColor.opacity(0.12))
+                        .frame(width: 36, height: 3)
+                }
+            }
+            .offset(y: contentSlide)
+            .opacity(contentRevealBlue)
+            .clipShape(RoundedRectangle(cornerRadius: blueCornerRadius))
+        }
+    }
+```
+
+- [ ] **Step 4: Remove now-unused static `goldRotation`/`blueRotation` usage from rotation effects on the orbs in `body`**
+
+The outer `.rotationEffect(.degrees(goldRotation))` and `.rotationEffect(.degrees(blueRotation))` applied on the orbs in `body` (currently around lines 123 and 130) **stay** — they drive the larger rotation used in Phases 1 and 3 (`-18°`, `-8°`, `0°` etc.). The new wobble composes on top via `PhaseAnimator` inside the orb.
+
+No change needed in `body` for this step — just confirming. If you accidentally removed the outer `.rotationEffect`, restore it.
+
+- [ ] **Step 5: Build**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 6: Simulator check**
+
+Run with Reduce Motion OFF. During Phase 2 (expansion), each orb should tilt subtly: ±5° wobble with a 0.15s offset between gold and blue. Ends at 0° by Phase 3.
+
+Pass criteria:
+- Wobble is visible but subtle — not distracting.
+- Orbs still don't visually collide (widened positions from Task 4 plus ±5° rotation should still clear).
+- Wobble does NOT run when Reduce Motion is ON (because `phase == 2` is never reached — `applyReducedMotionState()` jumps straight to phase 4).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git add ios/Astral/App/RootView.swift
+git commit -m "[ios] AST-5 add Phase 2 wobble via local PhaseAnimator
+
+Each orb tilts ±5° during expansion using an inner PhaseAnimator
+keyed on phase == 2. Blue is offset 0.15s from gold. Composes on
+top of the outer rotationEffect that drives Phases 1 and 3.
+
+Closes AST-5.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Full Manual Verification Matrix
+
+**Files:** none (test only)
+
+- [ ] **Step 1: Reduce Motion OFF — iPhone 15 simulator**
+
+Launch fresh. Watch the full sequence:
+- Phase 1: tiny blobs pop in at corners, drift slightly inward. Gold appears first; blue 0.2s later.
+- Phase 2: dramatic spring expansion. Orbs wobble ±5°, offset by 0.15s. Gold content reveals first; blue content follows. No overlap at any point.
+- Phase 3: orbs contract + morph to rounded rectangles with a bouncy spring settle. Title "Astral" blurs in from `blur(8)` to sharp.
+- Phase 4: subtitle "What are you reading?" fades in, then labels "Comics" / "Fan Fiction".
+- Tap left half: scales + fades, then navigates to ComicTab.
+
+- [ ] **Step 2: Reduce Motion OFF — iPhone SE simulator (375pt)**
+
+Repeat. Specifically verify no orb overlap during Phase 2 on the narrowest supported width. If overlap is visible, STOP and report — the design-risk fallback is to cap Phase 2 orb size at 130pt.
+
+- [ ] **Step 3: Reduce Motion ON**
+
+Settings → Accessibility → Motion → Reduce Motion → ON. Relaunch Astral.
+- Orbs are at final resting positions immediately.
+- ~0.3s opacity cross-fade brings everything in.
+- Title is present, sharp, at full scale.
+- Labels and subtitle visible.
+- Taps work instantly.
+- No ambient background drift.
+
+- [ ] **Step 4: Rapid dismiss**
+
+With Reduce Motion OFF, launch app and immediately (mid-Phase 2) tap either half. App should navigate cleanly; no crash, no spurious warnings in Xcode console. Relaunch — no state corruption.
+
+- [ ] **Step 5: Grep confirmation**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+grep -n DispatchQueue ios/Astral/App/RootView.swift
+```
+
+Expected: no output.
+
+```bash
+grep -n "contentReveal\b" ios/Astral/App/RootView.swift
+```
+
+Expected: no output (only `contentRevealGold` and `contentRevealBlue` should remain — the `\b` word boundary ensures we don't match the two new names).
+
+- [ ] **Step 6: (Optional) UI test sanity**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp/ios/Astral" && xcodebuild -scheme Astral -sdk iphonesimulator -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' test -only-testing:AstralUITests 2>&1 | tail -30
+```
+
+Expected: UI tests pass (they bypass landing via `--uitesting`). If a test fails, fix only if it relates to this change — unrelated UI-test failures are out of scope.
+
+No commit for this task.
+
+---
+
+## Task 12: Open Pull Request
+
+**Files:** none (git + gh operation)
+
+- [ ] **Step 1: Push branch**
+
+```bash
+cd "/Users/nicknetraganti/Desktop/Developer Stuff/IosApp/IosTestApp"
+git push -u origin feature/ast-1-landing-animation-redesign
+```
+
+- [ ] **Step 2: Create the PR targeting `development`**
+
+```bash
+gh pr create --base development --title "[ios] AST-1 landing animation redesign" --body "$(cat <<'EOF'
+## Summary
+- Fix Phase 2 orb overlap by widening positions to ±halfW * 0.38 and removing the 1.8s mid-drift step.
+- Replace all `DispatchQueue.main.asyncAfter` in `runAnimation()` with `withAnimation(...) completion:` chaining plus an `animationToken` cancellation guard.
+- Honor `accessibilityReduceMotion` — skip to final state with a 0.3s cross-fade.
+- Polish: staggered content reveal (gold → blue), Phase 2 wobble via local `PhaseAnimator`, `.bouncy` Phase 3 finale, title blur-in, `PressButtonStyle` on tap zones.
+
+Spec: `docs/superpowers/specs/2026-04-17-landing-animation-redesign-design.md`
+
+## Test plan
+- [ ] Reduce Motion OFF on iPhone 15 simulator — full sequence plays, no orb overlap.
+- [ ] Reduce Motion OFF on iPhone SE (375pt) simulator — no overlap on narrowest supported width.
+- [ ] Reduce Motion ON — cross-fade only, orbs at final positions, taps immediate.
+- [ ] Rapid-dismiss mid-animation — no crash, correct tab lands.
+- [ ] `grep DispatchQueue ios/Astral/App/RootView.swift` returns empty.
+
+Fixes AST-1
+Fixes AST-2
+Fixes AST-3
+Fixes AST-4
+Fixes AST-5
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report the PR URL back**
+
+The `gh pr create` output prints the PR URL — paste it into the conversation so the user can open it.
+
+---
+
+## Self-Review Notes (completed before handoff)
+
+- Every spec section has a task: AST-2 → Task 4; AST-3 → Tasks 2–3; AST-4 → Task 5; AST-5 #1 → Task 6; AST-5 #2 → Task 10; AST-5 #3 → Task 7; AST-5 #4 → Tasks 1 (var added) + 8 (animation); AST-5 #5 → Task 9.
+- New `@State` added in Task 1 and referenced by Tasks 6, 8, 10.
+- `applyReducedMotionState()` in Task 5 sets both `contentRevealGold` and `contentRevealBlue` (consistent with Task 1's rename).
+- `runPhase2MidDrift()` introduced in Task 2 and removed in Task 4 — intentional; Task 3 chains through it so Task 3 is verifiable independently of the overlap fix.
+- Phase 1's outer `rotationEffect(.degrees(goldRotation))` on `body` stays; the inner `PhaseAnimator` wobble composes on top — explicit call-out in Task 10 Step 4 to prevent accidental removal.
+- No placeholders, no "add error handling" stubs.

--- a/docs/superpowers/specs/2026-04-17-ast12-fanfic-thumbnail-fallback-design.md
+++ b/docs/superpowers/specs/2026-04-17-ast12-fanfic-thumbnail-fallback-design.md
@@ -3,7 +3,7 @@
 **Date**: 2026-04-17
 **Issue**: AST-12
 **Branch**: `feature/ast-12-fanfic-thumbnail-fallback`
-**Status**: Design / Pre-implementation
+**Status**: Design / Pre-implementation — open questions answered 2026-04-17
 
 ---
 
@@ -48,18 +48,31 @@ app.include_router(fanfic_thumbnails.router, prefix="/api/v1")
 
 ```
 GET /api/v1/fanfic-thumbnails/random
+GET /api/v1/fanfic-thumbnails/random?count=N
 ```
 
-**Response (200 OK)**
+**Query parameter `count`** (optional, default `1`): integer in range [1, 50]. Capped at `FANFIC_THUMBNAIL_COUNT = 50`. Values > 50 are clamped to 50. Enables the iOS migration to fetch N random paths in a single round-trip.
+
+**Response — single (count absent or count=1, 200 OK)**
 ```json
 { "path": "fanfic-thumbnails/17.jpg" }
+```
+
+**Response — batch (count > 1, 200 OK)**
+```json
+{ "paths": ["fanfic-thumbnails/17.jpg", "fanfic-thumbnails/3.jpg", "fanfic-thumbnails/42.jpg"] }
 ```
 
 **Response schema** (`backend/app/schemas/fanfic_thumbnail.py`):
 ```python
 class RandomThumbnailResponse(BaseModel):
-    path: str  # relative to staticBaseURL, e.g. "fanfic-thumbnails/17.jpg"
+    path: str  # present when count=1 (or absent); relative to staticBaseURL
+
+class RandomThumbnailBatchResponse(BaseModel):
+    paths: list[str]  # present when count > 1; length == min(count, 50)
 ```
+
+The endpoint returns `RandomThumbnailResponse` when `count` is absent or `1`, and `RandomThumbnailBatchResponse` when `count > 1`. Paths are sampled with replacement from `random.randint(1, FANFIC_THUMBNAIL_COUNT)`.
 
 **Implementation**: `random.randint(1, FANFIC_THUMBNAIL_COUNT)` where `FANFIC_THUMBNAIL_COUNT = 50`. No DB query needed. The endpoint is stateless.
 
@@ -102,10 +115,16 @@ which resolves to e.g. `http://192.168.0.108:8000/static/fanfic-thumbnails/17.jp
 **50 images** = 6 base colors × ~8 gradient directions + some with overlay symbols (book, scroll, quill glyphs as Unicode text rendered at large size). Each JPG < 30 KB at 400×600 with 70% JPEG quality.
 
 **Seeding script**: `backend/scripts/seed_fanfic_thumbnails.py`
-- Generates SVG as a Python string (no Pillow needed for basic gradients; Pillow used only to rasterize to JPG).
+- Generates gradient JPGs using Pillow (rasterization to 400×600 JPG).
 - Output: `/mnt/astral-media/fanfic-thumbnails/1.jpg` through `50.jpg`.
 - Safe to re-run — skips files that already exist (unless `--force`).
 - Must be run once during initial deploy and again when curated art is available.
+
+**Backend dependencies**: `Pillow>=10.0` must be present in `backend/requirements.txt`. Add the following line if not already present:
+```
+Pillow>=10.0
+```
+This is required for the seeding script; it is not a runtime dependency of the FastAPI app itself.
 
 **docker-compose.local.yml note**: A `volumes` entry already mounts `astral_media` at `/mnt/astral-media`. The script runs against that path inside the backend container via:
 ```bash
@@ -166,21 +185,30 @@ try? modelContext.save()
 
 ### Migration: existing fanfics with nil thumbnailPath
 
-Added to `FanficLibraryViewModel.fetchFanfics()` at the end of the existing sync, after `lastSyncTime = .now`:
+Added to `FanficLibraryViewModel.fetchFanfics()` at the end of the existing sync, after `lastSyncTime = .now`.
+
+**Batch approach** (replaces the previous N-sequential-call approach): iOS fetches all N random paths in a single round-trip using `?count=N`, then assigns them one-per-fanfic locally. This avoids N sequential HTTP calls for users with many existing fanfics.
 
 ```swift
-// One-off migration: assign thumbnails to fanfics with nil paths
+// One-off migration: assign thumbnails to fanfics with nil paths (batch variant)
 let nilThumbFanfics = allFanfics.filter { $0.thumbnailPath == nil }
-for fanfic in nilThumbFanfics {
-    if let dto = try? await APIClient.shared.request(.randomFanficThumbnail) as RandomThumbnailResponse {
-        fanfic.thumbnailPath = dto.path
+if !nilThumbFanfics.isEmpty {
+    let count = min(nilThumbFanfics.count, 50)
+    AstralLogger.info("Migration: \(nilThumbFanfics.count) fanfics need thumbnails", context: "FanficLibraryVM")
+    if let batch: RandomThumbnailBatchResponse = try? await APIClient.shared.request(
+        .randomFanficThumbnails(count: count)
+    ) {
+        for (fanfic, path) in zip(nilThumbFanfics, batch.paths) {
+            fanfic.thumbnailPath = path
+        }
+        // If more than 50 fanfics need thumbnails, remaining stay nil until next library open
+        try? modelContext.save()
+        AstralLogger.info("Migration: thumbnail assignment complete", context: "FanficLibraryVM")
     }
 }
-if !nilThumbFanfics.isEmpty {
-    try? modelContext.save()
-    AstralLogger.info("Migration: assigned thumbnails to \(nilThumbFanfics.count) fanfics", context: "FanficLibraryVM")
-}
 ```
+
+A second pass on next library open handles any fanfics beyond the 50-cap (capped by the server). In practice, a user with > 50 fanfics with nil paths is the very first migration run; subsequent runs will have at most a handful to assign.
 
 **Why in `fetchFanfics` not `RootView.onAppear`**: `fetchFanfics` already has the `ModelContext`, runs under `@MainActor`, and already handles URLError gracefully. The migration guard is `thumbnailPath == nil` — once assigned, it never re-runs for that fanfic. Runs on every library load but only does work when needed.
 
@@ -201,14 +229,24 @@ if !nilThumbFanfics.isEmpty {
 
 ---
 
+## Pre-implementation Checks
+
+Before writing code, verify each of the following:
+
+1. **`CachedAsyncImage` 404 audit**: Read `ios/Astral/Packages/DesignSystem/Sources/DesignSystem/Components/CachedAsyncImage.swift` (or wherever it lives). Confirm that an HTTP 404 from the static server does not crash the app — it must fall through silently to `PlaceholderThumbnail`. If it crashes or hangs on 404, add a guard before proceeding to Tasks 3–5.
+
+2. **`AppConfig.staticBaseURL` trailing `/` audit**: Read `ios/Astral/Packages/Core/Sources/Core/AppConfig.swift`. Verify that all three environment branches (`#if targetEnvironment(simulator)`, `#else DEBUG`, and release) set `staticBaseURL` with a trailing `/`. A missing trailing slash produces `"/staticfanfic-thumbnails/..."` 404s. Fix any branch that is missing it before implementing the iOS tasks.
+
+---
+
 ## Risks and Gotchas
 
 1. **Static file caching on iOS**: `URLSession` default cache may cache the image at the resolved URL. Since images are numbered 1–50 and static, this is desirable. No cache-busting needed.
-2. **`AppConfig.staticBaseURL` trailing slash**: CLAUDE.md explicitly flags this. The path returned (`fanfic-thumbnails/17.jpg`) has no leading slash. `StoryThumbnail` uses `CachedAsyncImage(remotePath:baseURL:)` — verify `CachedAsyncImage` joins them correctly. If it uses simple string concatenation, `staticBaseURL` must end with `/` (already enforced in config).
+2. **`AppConfig.staticBaseURL` trailing slash**: CLAUDE.md explicitly flags this. The path returned (`fanfic-thumbnails/17.jpg`) has no leading slash. `StoryThumbnail` uses `CachedAsyncImage(remotePath:baseURL:)` — `staticBaseURL` must end with `/` in all three environment branches (simulator, device, prod). See Pre-implementation Checks above.
 3. **CORS**: Static file serving uses FastAPI `StaticFiles` — no CORS headers needed for same-origin WKWebView or URLSession requests.
-4. **Seeding script dependencies**: Pillow must be available in the backend Docker image. If not installed, add to `requirements.txt`. Alternative: generate pure JPEG bytes with struct-based JFIF header (avoids dependency), but Pillow is simpler and already likely present.
+4. **Seeding script dependencies**: `Pillow>=10.0` is required in `backend/requirements.txt` (decision: add it). See Backend Dependencies section in Image Sourcing Plan.
 5. **`fanfic_thumbnails` key conflict with `fanfic` router prefix**: The new router uses prefix `/fanfic-thumbnails` not `/fanfic` — no routing conflict with existing `/fanfic/{id}` routes.
-6. **N+1 requests in migration**: If a user has 200 fanfics with nil paths, migration fires 200 sequential requests on first library load. Mitigation: the endpoint is local-LAN-only, sub-1ms latency, no DB hit. Acceptable. Could batch with a `?count=N` variant later if needed.
+6. **Migration N+1 resolved**: The `?count=N` batch endpoint eliminates sequential per-fanfic requests. The iOS migration issues one HTTP call for up to 50 fanfics. Fanfics beyond 50 are handled on the next library open (max 50 per pass, limited by the server cap).
 7. **SwiftData save contention**: Both `syncActiveJobs` and `fetchFanfics` may run concurrently. Both use `try? modelContext.save()` — SwiftData handles concurrent writes on the same context via `@MainActor` isolation.
 
 ---
@@ -216,17 +254,32 @@ if !nilThumbFanfics.isEmpty {
 ## Testing
 
 ### Backend
-- Unit test `GET /api/v1/fanfic-thumbnails/random` returns 200 with `path` matching `fanfic-thumbnails/\d+.jpg`.
+- Unit test `GET /api/v1/fanfic-thumbnails/random` (no count) returns 200 with `path` matching `fanfic-thumbnails/\d+.jpg`.
 - Verify `int` is in range [1, 50].
 - Test 10 calls return at least 3 distinct values (probabilistic, retry-tolerant).
+- `GET /api/v1/fanfic-thumbnails/random?count=5` returns 200 with `paths` array of length 5, each matching `fanfic-thumbnails/\d+.jpg`.
+- `?count=60` is clamped to 50 — response `paths` length is 50.
+- `?count=1` returns `RandomThumbnailResponse` (single `path` field, not batch).
 - Seeding script: verify it creates 50 files, skips existing, respects `--force`.
 
 ### iOS
 - `StoryThumbnail` with a valid `thumbnailPath` renders an image (not placeholder).
 - `StoryThumbnail` with nil path renders `PlaceholderThumbnail`.
-- `fetchFanfics` migration: inject a fanfic with nil `thumbnailPath`, mock endpoint returns `{"path": "fanfic-thumbnails/3.jpg"}`, assert path is written and saved.
-- `syncActiveJobs`: mock a job transitioning to `"complete"`, assert thumbnail assigned.
+- `fetchFanfics` migration (batch): inject 3 fanfics with nil `thumbnailPath`, mock batch endpoint returns `{"paths": ["fanfic-thumbnails/3.jpg", "fanfic-thumbnails/7.jpg", "fanfic-thumbnails/12.jpg"]}`, assert all 3 paths are written and saved.
+- `syncActiveJobs`: mock a job transitioning to `"complete"`, assert thumbnail assigned via single-path endpoint.
 - Offline: mock `APIClient` to throw `URLError`, assert `thumbnailPath` stays nil, no crash.
+- `CachedAsyncImage` 404: confirm component falls through to nil/failure state without crashing (pre-implementation check).
+
+---
+
+## Answered Open Questions (2026-04-17)
+
+The following questions were resolved by user input and are now reflected throughout this spec:
+
+1. **Pillow dependency** — Yes: add `Pillow>=10.0` to `backend/requirements.txt`. The seeding script requires it.
+2. **`CachedAsyncImage` 404 handling** — Yes: add a pre-implementation audit task. If it crashes on 404, fix before proceeding.
+3. **Batch migration endpoint** — Yes: add `?count=N` to `GET /api/v1/fanfic-thumbnails/random`. iOS migration uses one batch call instead of N sequential calls. Default `count=1` (absent param) keeps existing single-path response shape.
+4. **`AppConfig.staticBaseURL` trailing slash** — Yes: audit all three environment branches (simulator, device debug, prod release) before implementing iOS tasks.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-17-ast12-fanfic-thumbnail-fallback-design.md
+++ b/docs/superpowers/specs/2026-04-17-ast12-fanfic-thumbnail-fallback-design.md
@@ -1,0 +1,243 @@
+# AST-12 — Fanfic Thumbnail Fallback: Design Spec
+
+**Date**: 2026-04-17
+**Issue**: AST-12
+**Branch**: `feature/ast-12-fanfic-thumbnail-fallback`
+**Status**: Design / Pre-implementation
+
+---
+
+## Summary
+
+Fanfic library cards render blank colored placeholders because `LocalFanfic.thumbnailPath` is almost never populated for scraped fanfics. This spec describes a server-side random-thumbnail endpoint, 50 gradient-SVG-based seed images, iOS integration at the right hook point (scrape finalization poll), and a one-pass migration for existing fanfics with nil paths.
+
+---
+
+## Goals
+
+1. Every fanfic in the library has a visually distinct thumbnail within one app launch after scrape completion.
+2. Backend serves random paths — iOS does no selection logic.
+3. Backend unreachable at assignment time is fully silent — `PlaceholderThumbnail` continues to render.
+4. Seed images are lightweight enough to keep in the Docker volume without significant IO cost.
+5. The solution is additive — zero changes to existing scrape flow timing or the `FanficResponse` DTO shape.
+
+---
+
+## Non-Goals
+
+- Changing how `thumbnailPath` is stored on the backend `Fanfic` ORM model (field already exists).
+- Scraping cover art from AO3 or FFNet (no consistent image on those pages).
+- Bundling images with the IPA.
+- User ability to choose or upload thumbnails.
+- Any CDN or cache-busting infrastructure (images are static).
+
+---
+
+## Backend API Design
+
+### New router file
+`backend/app/api/v1/routes/fanfic_thumbnails.py`
+
+Mounted in `main.py` alongside existing routers:
+```python
+from app.api.v1.routes import fanfic_thumbnails
+app.include_router(fanfic_thumbnails.router, prefix="/api/v1")
+```
+
+### Endpoint
+
+```
+GET /api/v1/fanfic-thumbnails/random
+```
+
+**Response (200 OK)**
+```json
+{ "path": "fanfic-thumbnails/17.jpg" }
+```
+
+**Response schema** (`backend/app/schemas/fanfic_thumbnail.py`):
+```python
+class RandomThumbnailResponse(BaseModel):
+    path: str  # relative to staticBaseURL, e.g. "fanfic-thumbnails/17.jpg"
+```
+
+**Implementation**: `random.randint(1, FANFIC_THUMBNAIL_COUNT)` where `FANFIC_THUMBNAIL_COUNT = 50`. No DB query needed. The endpoint is stateless.
+
+**Error handling**: No 4xx/5xx expected — it is pure computation. If the thumbnails directory is missing on disk the static server would 404 when iOS fetches the image, which is the correct degradation path (iOS falls back to `PlaceholderThumbnail` via `CachedAsyncImage` failure).
+
+**Rate limiting**: Not warranted. The endpoint is hit at most once per fanfic creation or migration pass. No ARQ job needed. The endpoint is idempotent — iOS may call it again on retry without side effects.
+
+**No auth required**: Consistent with the existing pattern — no bearer token on any Astral API endpoint (private LAN + sideloaded app assumption).
+
+### Static file serving
+
+Files already served by the existing `StaticFiles` mount in `main.py`:
+```python
+app.mount("/static", StaticFiles(directory=settings.block_volume_path), name="static")
+```
+`block_volume_path` defaults to `/tmp/astral-media` (dev) and `/mnt/astral-media` (OCI). No change needed.
+
+iOS constructs the full URL as:
+```
+AppConfig.staticBaseURL + "fanfic-thumbnails/17.jpg"
+```
+which resolves to e.g. `http://192.168.0.108:8000/static/fanfic-thumbnails/17.jpg`.
+
+---
+
+## Image Sourcing Plan
+
+**Decision (autonomous)**: Generate 50 gradient-based SVG thumbnails at startup and rasterize to 400×600 JPG at seeding time using a one-off Python script. These are placeholder seeds, styled to match the Astral dark theme (using the same 6-color palette as `PlaceholderThumbnail`). A `TODO` comment marks where curated art should replace them.
+
+**Palette** (matches iOS `PlaceholderThumbnail` colors):
+```
+#2A2A4A  deep indigo
+#4A2A2A  deep burgundy
+#2A4A34  deep forest
+#40324A  deep plum
+#324044  deep teal
+#3A3A2A  deep olive
+```
+
+**50 images** = 6 base colors × ~8 gradient directions + some with overlay symbols (book, scroll, quill glyphs as Unicode text rendered at large size). Each JPG < 30 KB at 400×600 with 70% JPEG quality.
+
+**Seeding script**: `backend/scripts/seed_fanfic_thumbnails.py`
+- Generates SVG as a Python string (no Pillow needed for basic gradients; Pillow used only to rasterize to JPG).
+- Output: `/mnt/astral-media/fanfic-thumbnails/1.jpg` through `50.jpg`.
+- Safe to re-run — skips files that already exist (unless `--force`).
+- Must be run once during initial deploy and again when curated art is available.
+
+**docker-compose.local.yml note**: A `volumes` entry already mounts `astral_media` at `/mnt/astral-media`. The script runs against that path inside the backend container via:
+```bash
+docker compose exec backend python scripts/seed_fanfic_thumbnails.py
+```
+
+---
+
+## iOS Integration
+
+### New DTO
+
+Add to `ios/Astral/Packages/Networking/Sources/Networking/DTOs/FanficDTOs.swift`:
+```swift
+public struct RandomThumbnailResponse: Codable, Sendable {
+    public let path: String
+}
+```
+
+### New Endpoint
+
+Add to `ios/Astral/Packages/Networking/Sources/Networking/Endpoints.swift` under the Fanfic section:
+```swift
+static var randomFanficThumbnail: Endpoint {
+    Endpoint(path: "/fanfic-thumbnails/random")
+}
+```
+
+### New APIClient helper
+
+The standard `APIClient.request<T>` method handles this without change. Call site:
+```swift
+let dto: RandomThumbnailResponse = try await APIClient.shared.request(.randomFanficThumbnail)
+fanfic.thumbnailPath = dto.path
+```
+
+### Hook point: `FanficScrapesView.syncActiveJobs()`
+
+The right place to assign a thumbnail is when a scrape job transitions to `"complete"` or `"partial"` status AND the associated `LocalFanfic.thumbnailPath == nil`. This is in the existing polling loop in `FanficScrapesView.syncActiveJobs()`, which already upserts scrape job state every 5 seconds.
+
+**After** the existing job-status upsert loop, add:
+```swift
+// Assign fallback thumbnails for newly-completed fanfics with nil paths
+for job in fanficJobs where (job.status == "complete" || job.status == "partial") {
+    guard let fanfic = fanfics.first(where: { $0.id == job.storyId }),
+          fanfic.thumbnailPath == nil else { continue }
+    if let dto = try? await APIClient.shared.request(.randomFanficThumbnail) as RandomThumbnailResponse {
+        fanfic.thumbnailPath = dto.path
+    }
+}
+try? modelContext.save()
+```
+
+**Rationale for this hook point vs. alternatives**:
+- `FanficBrowserViewModel.extractCookiesAndScrape()` — too early; scrape is still queued, `LocalFanfic` may not exist yet.
+- `FanficLibraryViewModel.fetchFanfics()` — wrong owner; this runs every 2 minutes and would re-fetch for every library load. Thumbnail assignment is a one-time side-effect, not a library concern.
+- `FanficScrapesView.syncActiveJobs()` — polling already runs every 5s; this is the right "scrape just completed" detector. Assignment fires at most once per fanfic (guarded by `thumbnailPath == nil`).
+
+### Migration: existing fanfics with nil thumbnailPath
+
+Added to `FanficLibraryViewModel.fetchFanfics()` at the end of the existing sync, after `lastSyncTime = .now`:
+
+```swift
+// One-off migration: assign thumbnails to fanfics with nil paths
+let nilThumbFanfics = allFanfics.filter { $0.thumbnailPath == nil }
+for fanfic in nilThumbFanfics {
+    if let dto = try? await APIClient.shared.request(.randomFanficThumbnail) as RandomThumbnailResponse {
+        fanfic.thumbnailPath = dto.path
+    }
+}
+if !nilThumbFanfics.isEmpty {
+    try? modelContext.save()
+    AstralLogger.info("Migration: assigned thumbnails to \(nilThumbFanfics.count) fanfics", context: "FanficLibraryVM")
+}
+```
+
+**Why in `fetchFanfics` not `RootView.onAppear`**: `fetchFanfics` already has the `ModelContext`, runs under `@MainActor`, and already handles URLError gracefully. The migration guard is `thumbnailPath == nil` — once assigned, it never re-runs for that fanfic. Runs on every library load but only does work when needed.
+
+**Backend unreachable**: Both hook points use `try?` — failure is silently swallowed. `thumbnailPath` stays nil; `StoryThumbnail` renders `PlaceholderThumbnail`. No user-visible error.
+
+---
+
+## Migration Strategy
+
+| Scenario | Behavior |
+|---|---|
+| Fresh install, no fanfics | No-op |
+| Existing fanfics, thumbnailPath nil | `fetchFanfics` migration assigns on next library open |
+| New scrape completed | `syncActiveJobs` assigns within ~5s of completion |
+| Backend unreachable | Silent no-op, PlaceholderThumbnail renders |
+| thumbnailPath already set | Neither hook assigns — guarded by `== nil` check |
+| Images not yet seeded on disk | Static file 404 → `CachedAsyncImage` fails → PlaceholderThumbnail |
+
+---
+
+## Risks and Gotchas
+
+1. **Static file caching on iOS**: `URLSession` default cache may cache the image at the resolved URL. Since images are numbered 1–50 and static, this is desirable. No cache-busting needed.
+2. **`AppConfig.staticBaseURL` trailing slash**: CLAUDE.md explicitly flags this. The path returned (`fanfic-thumbnails/17.jpg`) has no leading slash. `StoryThumbnail` uses `CachedAsyncImage(remotePath:baseURL:)` — verify `CachedAsyncImage` joins them correctly. If it uses simple string concatenation, `staticBaseURL` must end with `/` (already enforced in config).
+3. **CORS**: Static file serving uses FastAPI `StaticFiles` — no CORS headers needed for same-origin WKWebView or URLSession requests.
+4. **Seeding script dependencies**: Pillow must be available in the backend Docker image. If not installed, add to `requirements.txt`. Alternative: generate pure JPEG bytes with struct-based JFIF header (avoids dependency), but Pillow is simpler and already likely present.
+5. **`fanfic_thumbnails` key conflict with `fanfic` router prefix**: The new router uses prefix `/fanfic-thumbnails` not `/fanfic` — no routing conflict with existing `/fanfic/{id}` routes.
+6. **N+1 requests in migration**: If a user has 200 fanfics with nil paths, migration fires 200 sequential requests on first library load. Mitigation: the endpoint is local-LAN-only, sub-1ms latency, no DB hit. Acceptable. Could batch with a `?count=N` variant later if needed.
+7. **SwiftData save contention**: Both `syncActiveJobs` and `fetchFanfics` may run concurrently. Both use `try? modelContext.save()` — SwiftData handles concurrent writes on the same context via `@MainActor` isolation.
+
+---
+
+## Testing
+
+### Backend
+- Unit test `GET /api/v1/fanfic-thumbnails/random` returns 200 with `path` matching `fanfic-thumbnails/\d+.jpg`.
+- Verify `int` is in range [1, 50].
+- Test 10 calls return at least 3 distinct values (probabilistic, retry-tolerant).
+- Seeding script: verify it creates 50 files, skips existing, respects `--force`.
+
+### iOS
+- `StoryThumbnail` with a valid `thumbnailPath` renders an image (not placeholder).
+- `StoryThumbnail` with nil path renders `PlaceholderThumbnail`.
+- `fetchFanfics` migration: inject a fanfic with nil `thumbnailPath`, mock endpoint returns `{"path": "fanfic-thumbnails/3.jpg"}`, assert path is written and saved.
+- `syncActiveJobs`: mock a job transitioning to `"complete"`, assert thumbnail assigned.
+- Offline: mock `APIClient` to throw `URLError`, assert `thumbnailPath` stays nil, no crash.
+
+---
+
+## Decisions Made Autonomously
+
+1. **Image sourcing**: Gradient-SVG-generated JPGs (50 files, ~30 KB each) seeded via `backend/scripts/seed_fanfic_thumbnails.py`. Rationale: avoids licensing concerns, matches dark Astral palette, zero external dependencies at runtime, trivially replaceable with curated art by re-running the script with real images.
+
+2. **Server-side randomization**: Endpoint returns a single random path. iOS does no selection. Rationale: simpler iOS code, consistent with the spec direction, and the selection logic lives in one place.
+
+3. **Hook point for new scrapes**: `FanficScrapesView.syncActiveJobs()` polling loop. Rationale: this is the only place that observes scrape-job status transitions; assigning there keeps library ViewModel free of thumbnail-assignment responsibility.
+
+4. **Hook point for migration**: `FanficLibraryViewModel.fetchFanfics()` end-of-sync block. Rationale: already runs on app foreground, has ModelContext, handles URLError, and the `thumbnailPath == nil` guard means it's effectively a one-shot.
+
+5. **No new router prefix collision**: Using `/fanfic-thumbnails` (hyphenated) avoids shadowing the existing `/fanfic` prefix router.

--- a/docs/superpowers/specs/2026-04-17-landing-animation-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-17-landing-animation-redesign-design.md
@@ -1,0 +1,210 @@
+# Landing Animation Redesign — Design
+
+- **Date**: 2026-04-17
+- **Linear**: [AST-1](https://linear.app/nnetraganti/issue/AST-1) (parent), closes [AST-2](https://linear.app/nnetraganti/issue/AST-2), [AST-3](https://linear.app/nnetraganti/issue/AST-3), [AST-4](https://linear.app/nnetraganti/issue/AST-4), [AST-5](https://linear.app/nnetraganti/issue/AST-5)
+- **File**: `ios/Astral/App/RootView.swift` (only)
+- **Target**: iOS 17.2+
+
+## Summary
+
+Rewrite `MorphLandingView.runAnimation()` in a single pass to fix orb overlap, remove `DispatchQueue.main.asyncAfter` sequencing, add `accessibilityReduceMotion` support, and apply five polish touches (stagger, wobble, bouncy finale, title blur-in, press feedback on tap zones).
+
+The four sub-issues all modify the same ~130-line function, so they are implemented together as one PR.
+
+## Goals
+
+- No two orbs visually collide at any point in the sequence.
+- Animation sequencing uses SwiftUI-native primitives — no `DispatchQueue`.
+- `accessibilityReduceMotion == true` replaces the sequence with a ~0.3s cross-fade.
+- Landing animation feels intentional and polished (stagger, wobble, bouncy finale, blur-in title, pressable tap zones).
+- Performance remains smooth on supported devices (iPhone, iOS 17.2+).
+
+## Non-goals
+
+- Changing the color palette, orb content (book/scroll icons, manga panels, text lines), typography, or copy.
+- Redesigning `ComicTabView`/`FanficTabView` or the cross-fade from landing to tabs.
+- Replacing the `--uitesting` flag path (already skips landing).
+- Ported animation logic to an extracted package — keep it inline in `RootView.swift` for now.
+
+## Architecture
+
+Single-file change. `MorphLandingView` keeps its public shape:
+
+- Same `@State` vars, plus three new ones (listed below).
+- Same `body` layout and `goldOrb` / `blueOrb` subview composition.
+- Same phase enum semantics (`phase: 0…4`) and same final resting visuals.
+
+The rewrite is concentrated in:
+
+1. `runAnimation()` — sequencing via `withAnimation(...) completion:` chaining.
+2. `goldOrb` / `blueOrb` — a small local `PhaseAnimator` wraps the shape stack for the Phase 2 wobble.
+3. A new `applyReducedMotionState()` helper for the reduce-motion branch.
+
+### Sequencing — AST-3 (approach A)
+
+`withAnimation(_:_:completionCriteria:completion:)` (iOS 17+) drives the phase chain. Each phase may issue several parallel `withAnimation` calls (for distinct curves / delays); the `completion:` handler is attached only to the **driver** — the longest-running `withAnimation` in the phase. When the driver finishes (criteria: `.logicallyComplete`), the next phase is invoked:
+
+```
+runAnimation()
+├─ if reduceMotion → applyReducedMotionState(); return
+├─ start ambient drift
+└─ Phase 1: fade-in + corner drift
+   └─ completion → Phase 2: spring expand + single drift + staggered content reveal
+      └─ completion → Phase 3: bouncy morph + title scale/blur-in
+         └─ completion → Phase 4: subtitle + labels + enable taps
+```
+
+No `DispatchQueue.main.asyncAfter` remains in `runAnimation()`.
+
+### Cancellation
+
+Cancellation is handled by a token. Pattern (Phase 1 example — three parallel `withAnimation` calls, completion attached only to the longest, which is the drift animation at `0.5 + 1.2 = 1.7s`):
+
+```swift
+@State private var animationToken = UUID()
+
+let token = animationToken
+
+withAnimation(.easeOut(duration: 0.5).delay(0.3)) {
+    // gold fade-in state
+}
+withAnimation(.easeOut(duration: 0.5).delay(0.5)) {
+    // blue fade-in state
+}
+// Driver — longest; carries completion.
+withAnimation(.easeInOut(duration: 1.2).delay(0.5),
+              completionCriteria: .logicallyComplete) {
+    // drift state
+} completion: {
+    guard token == animationToken else { return }
+    phase = 2
+    runPhase2()
+}
+
+// on disappear:
+.onDisappear { animationToken = UUID() }
+```
+
+Any in-flight completion that fires after the view disappears is dropped.
+
+### New / modified `@State`
+
+- `contentRevealGold: Double = 0` and `contentRevealBlue: Double = 0` — replace the single `contentReveal` so gold and blue can stagger.
+- `titleBlur: CGFloat = 8` — animated to `0` during Phase 3 for blur-in.
+- `animationToken: UUID` — cancellation guard described above.
+
+Removed: the single `contentReveal` variable (replaced by the two above). `contentSlide` stays shared (both orbs' content slides up together; only the fade is staggered).
+
+## Overlap fix — AST-2
+
+Phase 2's mid-drift step (currently `DispatchQueue.main.asyncAfter(deadline: .now() + 1.8)` pulling orbs to ~68pt center distance at 140pt size) is **deleted**. Phase 2 uses a single positional animation with wider multipliers. Final positions:
+
+| Step            | Gold offset                              | Blue offset                              | Center gap | Orb size |
+| --------------- | ---------------------------------------- | ---------------------------------------- | ---------- | -------- |
+| Phase 1 drift   | `(-halfW * 0.45, -halfH * 0.5)`          | `(+halfW * 0.4, +halfH * 0.45)`          | ~330pt     | 24–30pt  |
+| Phase 2 expand  | `(-halfW * 0.38, -halfH * 0.2)`          | `(+halfW * 0.38, +halfH * 0.2)`          | ~148pt     | 135–140pt |
+| Phase 3 final   | `(-80, 30)`                              | `(+80, 30)`                              | 160pt      | 120pt    |
+
+At a 390pt screen width:
+- Phase 2 gap: `0.38 * 195 * 2 ≈ 148pt` ≥ `70 + 70 = 140pt` (clears 140pt orbs with ~8pt clearance).
+- Phase 3 gap: `160pt` ≥ `60 + 60 = 120pt` (clears 120pt orbs with 40pt clearance).
+
+At a 430pt screen (iPhone Pro Max), the Phase 2 gap grows to ~163pt — more clearance, same multipliers.
+
+AST-2's acceptance criterion calls for ≥20pt clearance. Phase 2 gets ~8pt on the narrowest supported width (iPhone SE/13 mini at 375pt: ~142pt gap = 2pt clearance). **Decision**: acceptable because (a) wobble rotation is ±5° so rotated orbs still clip via their bounding boxes, not their visuals (orb shape is a rounded rectangle, not a square), and (b) going wider shoves Phase 2 visually close to the Phase 1 corners, losing the "expansion" beat. If testing shows collision on 375pt devices, we'll either cap `goldSize`/`blueSize` at 130pt during Phase 2 or bump multipliers to 0.4.
+
+## Polish — AST-5 (all 5)
+
+1. **Staggered content reveal.** In Phase 2, animate `contentRevealGold` with `.delay(0.3)` and `contentRevealBlue` with `.delay(0.45)`. `contentSlide` animates once in the same block.
+
+2. **Phase 2 wobble.** Inside `goldOrb` and `blueOrb`, wrap the shape stack in a `PhaseAnimator` keyed on `phase == 2`:
+   ```swift
+   PhaseAnimator([0.0, -5.0, 5.0, 0.0], trigger: phase == 2) { angle in
+       content.rotationEffect(.degrees(angle))
+   } animation: { _ in .easeInOut(duration: 0.7) }
+   ```
+   Runs once when Phase 2 is entered. Blue uses the same values with a `.delay(0.15)` so it's visually offset from gold.
+
+3. **Bouncy finale.** Phase 3 morph animation swaps from `.spring(response: 0.55, dampingFraction: 0.55)` to `.bouncy(duration: 0.5, extraBounce: 0.15)`.
+
+4. **Title blur-in.** Add `titleBlur: CGFloat = 8`, apply `.blur(radius: titleBlur)` on `Text("Astral")`, animate `titleBlur = 0` together with `titleScale` / `titleOpacity` inside Phase 3.
+
+5. **Press feedback on tap zones.** Replace:
+   ```swift
+   Color.clear.contentShape(Rectangle()).onTapGesture { onSelect(.comic) }
+   ```
+   with:
+   ```swift
+   Button { onSelect(.comic) } label: {
+       Color.clear.contentShape(Rectangle())
+   }
+   .pressEffect()
+   .accessibilityIdentifier(AccessibilityID.landingComicOrb)
+   ```
+   `pressEffect()` is `DesignSystem.PressButtonStyle` (already defined).
+
+## Reduce motion — AST-4
+
+```swift
+@Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+private func runAnimation() {
+    if reduceMotion {
+        applyReducedMotionState()
+        return
+    }
+    // ambient drift + phase chain
+}
+
+private func applyReducedMotionState() {
+    // Snap all state vars to Phase 4 final values (no animation).
+    goldSize = 120; blueSize = 120
+    goldOffset = CGSize(width: -80, height: 30)
+    blueOffset = CGSize(width: 80, height: 30)
+    goldRotation = 0; blueRotation = 0
+    goldBlobSkew = 1.0; blueBlobSkew = 1.0
+    goldCornerRadius = 28; blueCornerRadius = 28
+    goldGlow = 0.3; blueGlow = 0.3
+    contentRevealGold = 1.0; contentRevealBlue = 1.0
+    contentSlide = -5
+    titleScale = 1.0; titleBlur = 0
+
+    // Single cross-fade for the opacity values, no positional motion.
+    withAnimation(.easeOut(duration: 0.3)) {
+        goldOpacity = 1; blueOpacity = 1
+        titleOpacity = 1; subtitleOpacity = 1; labelOpacity = 1
+    }
+    phase = 4
+}
+```
+
+Ambient background drift (`ambientShift`) is **not** started when `reduceMotion == true` — it's a continuous motion loop, which reduce-motion users want gone.
+
+## Testing
+
+Manual simulator verification (primary — this is a visual change):
+
+- **Reduce Motion OFF** — Full sequence plays; no visible orb overlap in Phase 1/2/3; wobble visible in Phase 2; title blurs in during Phase 3; tapping a zone scales it ~4% and fades.
+- **Reduce Motion ON** (Settings → Accessibility → Motion → Reduce Motion) — Orbs appear at Phase 4 final positions with a single ~0.3s fade; taps immediately active; no ambient drift; no wobble.
+- **Rapid dismiss** — Trigger the landing, then immediately tap (or swap to reduce-motion mid-flight). No crash, no dangling state.
+- **Screen sizes** — Verify on iPhone SE (375pt), iPhone 15 (393pt), iPhone 15 Pro Max (430pt). Check Phase 2 clearance on the 375pt device specifically.
+
+Build:
+```
+cd ios/Astral && xcodebuild -scheme Astral -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,id=8FF2D1FB-E342-4E2A-BFB6-F608B18609DF' build
+```
+
+UI tests: existing `--uitesting` flag sets `showLanding = false` at launch, so the landing view is bypassed. No UI-test changes needed.
+
+## Risks / open questions
+
+- **Phase 2 clearance on 375pt devices.** Mid-drift deletion brings closest-approach to ~142pt center distance on the narrowest supported width. If wobble rotation causes visual clipping, fallback is to cap Phase 2 `goldSize`/`blueSize` at 130pt.
+- **`PhaseAnimator` nested inside `withAnimation`-driven parent.** Using `PhaseAnimator` locally inside `goldOrb`/`blueOrb` while the parent drives Phase 2's `phase` state should be safe — the `PhaseAnimator` only observes its own `trigger`. If any animation conflicts emerge, fallback is to drive wobble manually via a `Timer.publish` or a `withAnimation(.easeInOut(duration: 0.7).repeatCount(3, autoreverses: true))` applied to a new `@State var wobble: Double = 0`.
+
+## Rollout
+
+- Branch: `feature/ast-1-landing-animation-redesign` (branches from `development`).
+- Single commit (or small commit chain) prefixed `[ios] AST-1 …`.
+- PR body includes `Closes AST-1`, `Closes AST-2`, `Closes AST-3`, `Closes AST-4`, `Closes AST-5`.
+- Merge target: `development`.

--- a/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Scrapes/FanficScrapesView.swift
+++ b/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Scrapes/FanficScrapesView.swift
@@ -145,6 +145,17 @@ struct FanficScrapesView: View {
                 }
             }
             try? modelContext.save()
+
+            // AST-12: assign fallback thumbnails for newly-completed fanfics with nil paths
+            for job in fanficJobs where job.status == "complete" || job.status == "partial" {
+                guard let fanfic = fanfics.first(where: { $0.id == job.storyId }),
+                      fanfic.thumbnailPath == nil else { continue }
+                if let dto: RandomThumbnailResponse = try? await APIClient.shared.request(.randomFanficThumbnail) {
+                    fanfic.thumbnailPath = dto.path
+                    AstralLogger.info("Assigned thumbnail \(dto.path) to fanfic \(fanfic.id)", context: "FanficScrapes")
+                }
+            }
+            try? modelContext.save()
         } catch {
             AstralLogger.error("syncActiveJobs failed: \(error)", context: "FanficScrapes")
         }

--- a/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/ViewModels/FanficLibraryViewModel.swift
+++ b/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/ViewModels/FanficLibraryViewModel.swift
@@ -131,6 +131,23 @@ final class FanficLibraryViewModel {
             }
             try modelContext.save()
             lastSyncTime = .now
+
+            // AST-12: one-off migration — assign thumbnails to fanfics with nil paths (batch)
+            let nilThumbFanfics = allFanfics.filter { $0.thumbnailPath == nil }
+            if !nilThumbFanfics.isEmpty {
+                let count = min(nilThumbFanfics.count, 50)
+                AstralLogger.info("Migration: \(nilThumbFanfics.count) fanfics need thumbnails", context: "FanficLibraryVM")
+                if let batch: RandomThumbnailBatchResponse = try? await APIClient.shared.request(
+                    .randomFanficThumbnails(count: count)
+                ) {
+                    for (fanfic, path) in zip(nilThumbFanfics, batch.paths) {
+                        fanfic.thumbnailPath = path
+                    }
+                    // Fanfics beyond the 50-cap stay nil and are handled on the next library open
+                    try? modelContext.save()
+                    AstralLogger.info("Migration: thumbnail assignment complete", context: "FanficLibraryVM")
+                }
+            }
         } catch is URLError {
             errorMessage = "Backend unreachable — check Docker is running"
             AstralLogger.error("fetchFanfics: backend unreachable", context: "FanficLibraryVM")

--- a/ios/Astral/Packages/Networking/Sources/Networking/DTOs/FanficDTOs.swift
+++ b/ios/Astral/Packages/Networking/Sources/Networking/DTOs/FanficDTOs.swift
@@ -40,3 +40,11 @@ public struct FanficChapterResponse: Codable, Sendable, Identifiable {
     public let scrapeStatus: String
     public let createdAt: Date
 }
+
+public struct RandomThumbnailResponse: Codable, Sendable {
+    public let path: String
+}
+
+public struct RandomThumbnailBatchResponse: Codable, Sendable {
+    public let paths: [String]
+}

--- a/ios/Astral/Packages/Networking/Sources/Networking/Endpoints.swift
+++ b/ios/Astral/Packages/Networking/Sources/Networking/Endpoints.swift
@@ -125,6 +125,18 @@ public extension Endpoint {
     }
 }
 
+// MARK: - Fanfic Thumbnail Endpoints
+
+public extension Endpoint {
+    static var randomFanficThumbnail: Endpoint {
+        Endpoint(path: "/fanfic-thumbnails/random")
+    }
+
+    static func randomFanficThumbnails(count: Int) -> Endpoint {
+        Endpoint(path: "/fanfic-thumbnails/random?count=\(count)")
+    }
+}
+
 // MARK: - Author Endpoints
 
 public extension Endpoint {


### PR DESCRIPTION
## Summary

**Backend:**
- New router `backend/app/api/v1/routes/fanfic_thumbnails.py` — `GET /api/v1/fanfic-thumbnails/random` with optional `?count=N` (1..50) for batch random paths.
- Seed script `backend/scripts/seed_fanfic_thumbnails.py` — generates 50 gradient-JPG placeholders (400×600, ~30 KB each) matching the `PlaceholderThumbnail` dark Astral palette. Writes to `/mnt/astral-media/fanfic-thumbnails/`.
- `Pillow>=10.0` already pinned in `requirements.txt` (confirmed at `10.4.0`, no change needed).

**iOS:**
- `RandomThumbnailResponse` / `RandomThumbnailBatchResponse` DTOs + endpoint methods in `Networking`.
- On scrape finalize (`FanficScrapesView.syncActiveJobs()`): if `thumbnailPath == nil`, assign random.
- One-off migration in `FanficLibraryViewModel.fetchFanfics()`: batch request for N random paths covering all existing fanfics with nil thumbnail, assign locally via `zip`.
- Silent fallback: backend unreachable → `thumbnailPath` stays nil → `StoryThumbnail` renders existing `PlaceholderThumbnail`.

**Audits (all clean, no fix needed):**
- `CachedAsyncImage` 404: empty catch renders photo-icon placeholder cleanly.
- `AppConfig.staticBaseURL`: all 3 env branches already trail with `/`.
- `StoryThumbnail`: `if let path, !path.isEmpty` guard handles nil cleanly.

Spec: `docs/superpowers/specs/2026-04-17-ast12-fanfic-thumbnail-fallback-design.md`
Plan: `docs/superpowers/plans/2026-04-17-ast12-fanfic-thumbnail-fallback.md`

## Deploy step
After merge: `docker compose exec backend python scripts/seed_fanfic_thumbnails.py` to populate the volume.

## Test plan
- [ ] Deploy seed script; verify 50 JPGs in `/mnt/astral-media/fanfic-thumbnails/`.
- [ ] New scrape → fanfic gets a random thumbnail assigned on completion.
- [ ] Existing fanfic with nil `thumbnailPath` → gets one at next app launch.
- [ ] Kill backend → no crash, `PlaceholderThumbnail` renders.
- [ ] Run backend tests via `docker compose exec backend pytest tests/api/test_fanfic_thumbnails.py`.

Fixes AST-12

🤖 Generated with [Claude Code](https://claude.com/claude-code)