### PR TITLE
[backend] AST-19 permanent delete endpoints + services + ARQ media wipe

### DIFF
--- a/backend/app/api/v1/routes/comics.py
+++ b/backend/app/api/v1/routes/comics.py
@@ -70,3 +70,9 @@ async def delete_comic(comic_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
     deleted = await comic_service.soft_delete_comic(db, comic_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Comic not found")
+
+
+@router.delete("/{comic_id}/permanent", status_code=204)
+async def permanent_delete_comic_route(comic_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    await comic_service.permanent_delete_comic(db, comic_id)
+    # Idempotent: always 204, even for unknown ids

--- a/backend/app/api/v1/routes/fanfic.py
+++ b/backend/app/api/v1/routes/fanfic.py
@@ -51,3 +51,8 @@ async def delete_fanfic(fanfic_id: uuid.UUID, db: AsyncSession = Depends(get_db)
     deleted = await fanfic_service.soft_delete_fanfic(db, fanfic_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Fanfic not found")
+
+
+@router.delete("/{fanfic_id}/permanent", status_code=204)
+async def permanent_delete_fanfic_route(fanfic_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    await fanfic_service.permanent_delete_fanfic(db, fanfic_id)

--- a/backend/app/services/comic_service.py
+++ b/backend/app/services/comic_service.py
@@ -6,12 +6,13 @@ from typing import Optional
 from math import ceil
 import redis.asyncio as aioredis
 from arq.connections import ArqRedis
-from sqlalchemy import select, func
+from sqlalchemy import select, func, delete, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from app.models.comic import Comic, ComicChapter, Page, ComicAuthor, ComicTag
 from app.models.author import Author
 from app.models.scrape import ScrapeJob
+from app.models.progress import ReadingProgress
 from app.schemas.comic import ComicResponse, ComicChapterResponse, PageResponse, ComicUpdateRequest
 from app.schemas.shared import PaginatedResponse, AuthorResponse, TagResponse
 from app.core.constants import ArchiveStatus
@@ -287,4 +288,67 @@ async def soft_delete_comic(db: AsyncSession, comic_id: uuid.UUID) -> bool:
     comic.deleted_at = datetime.now(timezone.utc)
     await db.commit()
     await redis_cache.invalidate_comics(str(comic_id))
+    return True
+
+
+async def permanent_delete_comic(db: AsyncSession, comic_id: uuid.UUID) -> bool:
+    """Hard-delete a comic and every dependent row.
+
+    FK-safe order:
+      pages -> comic_chapters -> comic_authors -> comic_tags
+        -> reading_progress (polymorphic) -> comics
+        -> scrape_jobs (polymorphic; FK is comics.scrape_job_id,
+           so scrape_jobs must be deleted AFTER comics).
+
+    Enqueues a best-effort `comic_media_wipe_task` ARQ job to rmtree
+    both live and archive media directories. Idempotent: returns
+    True even when no comic row exists (iOS retry queue safety).
+    """
+    logger.info("permanent_delete_comic called | comic_id=%s", comic_id)
+
+    await db.execute(
+        delete(Page).where(
+            Page.chapter_id.in_(
+                select(ComicChapter.id).where(ComicChapter.comic_id == comic_id)
+            )
+        )
+    )
+    await db.execute(delete(ComicChapter).where(ComicChapter.comic_id == comic_id))
+    await db.execute(delete(ComicAuthor).where(ComicAuthor.comic_id == comic_id))
+    await db.execute(delete(ComicTag).where(ComicTag.comic_id == comic_id))
+    await db.execute(
+        delete(ReadingProgress).where(
+            and_(
+                ReadingProgress.content_type == "comic",
+                ReadingProgress.story_id == comic_id,
+            )
+        )
+    )
+    await db.execute(delete(Comic).where(Comic.id == comic_id))
+    await db.execute(
+        delete(ScrapeJob).where(
+            and_(
+                ScrapeJob.content_type == "comic",
+                ScrapeJob.story_id == comic_id,
+            )
+        )
+    )
+    await db.commit()
+
+    await redis_cache.invalidate_comics(str(comic_id))
+
+    # Best-effort media wipe — mirrors archive_comic enqueue pattern.
+    try:
+        r = await aioredis.from_url(settings.redis_url)
+        arq_redis = ArqRedis(r.connection_pool)
+        await arq_redis.enqueue_job("comic_media_wipe_task", str(comic_id))
+        await arq_redis.aclose()
+    except Exception as e:
+        logger.warning(
+            "permanent_delete_comic ARQ enqueue failed | comic_id=%s error=%s",
+            comic_id,
+            e,
+        )
+
+    logger.info("permanent_delete_comic done | comic_id=%s", comic_id)
     return True

--- a/backend/app/services/fanfic_service.py
+++ b/backend/app/services/fanfic_service.py
@@ -4,12 +4,17 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 from math import ceil
-from sqlalchemy import select, func
+import redis.asyncio as aioredis
+from arq.connections import ArqRedis
+from sqlalchemy import select, func, delete, and_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload, defer
 from app.models.fanfic import Fanfic, FanficChapter, FanficAuthor
+from app.models.scrape import ScrapeJob
+from app.models.progress import ReadingProgress
 from app.schemas.fanfic import FanficResponse, FanficChapterResponse
 from app.schemas.shared import PaginatedResponse, AuthorResponse
+from app.core.config import settings
 from app.cache import redis_cache
 
 logger = logging.getLogger(__name__)
@@ -189,4 +194,61 @@ async def soft_delete_fanfic(db: AsyncSession, fanfic_id: uuid.UUID) -> bool:
     fanfic.deleted_at = datetime.now(timezone.utc)
     await db.commit()
     await redis_cache.invalidate_fanfics(str(fanfic_id))
+    return True
+
+
+async def permanent_delete_fanfic(db: AsyncSession, fanfic_id: uuid.UUID) -> bool:
+    """Hard-delete a fanfic and every dependent row.
+
+    FK-safe order:
+      fanfic_chapters -> fanfic_authors -> reading_progress (polymorphic)
+        -> fanfics
+        -> scrape_jobs (polymorphic; FK is fanfics.scrape_job_id,
+           so scrape_jobs must be deleted AFTER fanfics).
+
+    Enqueues a best-effort `fanfic_media_wipe_task` ARQ job for pipeline
+    symmetry with comics (the task itself is a no-op today — fanfic has
+    no per-story media dir; thumbnails come from a shared pool and must
+    NOT be deleted). Idempotent: returns True even when no fanfic row
+    exists (iOS retry queue safety).
+    """
+    logger.info("permanent_delete_fanfic called | fanfic_id=%s", fanfic_id)
+
+    await db.execute(delete(FanficChapter).where(FanficChapter.fanfic_id == fanfic_id))
+    await db.execute(delete(FanficAuthor).where(FanficAuthor.fanfic_id == fanfic_id))
+    await db.execute(
+        delete(ReadingProgress).where(
+            and_(
+                ReadingProgress.content_type == "fanfic",
+                ReadingProgress.story_id == fanfic_id,
+            )
+        )
+    )
+    await db.execute(delete(Fanfic).where(Fanfic.id == fanfic_id))
+    await db.execute(
+        delete(ScrapeJob).where(
+            and_(
+                ScrapeJob.content_type == "fanfic",
+                ScrapeJob.story_id == fanfic_id,
+            )
+        )
+    )
+    await db.commit()
+
+    await redis_cache.invalidate_fanfics(str(fanfic_id))
+
+    # Best-effort media wipe — mirrors permanent_delete_comic enqueue pattern.
+    try:
+        r = await aioredis.from_url(settings.redis_url)
+        arq_redis = ArqRedis(r.connection_pool)
+        await arq_redis.enqueue_job("fanfic_media_wipe_task", str(fanfic_id))
+        await arq_redis.aclose()
+    except Exception as e:
+        logger.warning(
+            "permanent_delete_fanfic ARQ enqueue failed | fanfic_id=%s error=%s",
+            fanfic_id,
+            e,
+        )
+
+    logger.info("permanent_delete_fanfic done | fanfic_id=%s", fanfic_id)
     return True

--- a/backend/app/tasks/comic_media_wipe_task.py
+++ b/backend/app/tasks/comic_media_wipe_task.py
@@ -1,0 +1,33 @@
+import logging
+import shutil
+from pathlib import Path
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def comic_media_wipe_task(ctx, comic_id: str):
+    """Best-effort rmtree of comic media directories.
+
+    Wipes both the live path (`comics/{id}`) and the archive path
+    (`archive/comics/{id}`) because archive_status is not known at
+    wipe time. Never raises — any filesystem errors are logged and
+    swallowed so the ARQ job always marks as complete.
+    """
+    media_root = Path(settings.block_volume_path)
+    targets = [
+        media_root / "comics" / comic_id,
+        media_root / "archive" / "comics" / comic_id,
+    ]
+    for target in targets:
+        try:
+            shutil.rmtree(target, ignore_errors=True)
+        except Exception as e:
+            logger.warning(
+                "comic_media_wipe_task rmtree failed | comic_id=%s target=%s error=%s",
+                comic_id,
+                target,
+                e,
+            )
+    logger.info("comic_media_wipe_task done | comic_id=%s", comic_id)

--- a/backend/app/tasks/fanfic_media_wipe_task.py
+++ b/backend/app/tasks/fanfic_media_wipe_task.py
@@ -1,0 +1,16 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def fanfic_media_wipe_task(ctx, fanfic_id: str):
+    """Placeholder for per-fanfic asset cleanup.
+
+    Fanfic currently has no per-fanfic media directory — thumbnails come from
+    a shared pre-seeded pool and must NOT be deleted. This task exists for
+    symmetry with comic_media_wipe_task and to accommodate future per-fanfic
+    assets (e.g. scraped hero images, cached covers). Enqueuing it from
+    permanent_delete_fanfic keeps the pipeline symmetric and safe — it's a
+    no-op today.
+    """
+    logger.info("fanfic_media_wipe_task noop | fanfic_id=%s", fanfic_id)

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -7,6 +7,7 @@ from app.tasks.comic_scrape_task import comic_scrape_task
 from app.tasks.fanfic_scrape_task import fanfic_scrape_task
 from app.tasks.comic_archive_task import comic_archive_task
 from app.tasks.comic_unarchive_task import comic_unarchive_task
+from app.tasks.comic_media_wipe_task import comic_media_wipe_task
 from app.tasks.cleanup_task import cleanup_task
 from app.tasks.auto_update_task import auto_update_task
 
@@ -29,7 +30,7 @@ async def shutdown(ctx: dict) -> None:
 
 
 class WorkerSettings:
-    functions = [comic_scrape_task, fanfic_scrape_task, comic_archive_task, comic_unarchive_task]
+    functions = [comic_scrape_task, fanfic_scrape_task, comic_archive_task, comic_unarchive_task, comic_media_wipe_task]
     cron_jobs = [
         cron(cleanup_task, hour=3, minute=0),           # nightly at 03:00 UTC
         cron(auto_update_task, hour={0, 6, 12, 18}, minute=0),  # every 6 hours

--- a/backend/app/worker.py
+++ b/backend/app/worker.py
@@ -8,6 +8,7 @@ from app.tasks.fanfic_scrape_task import fanfic_scrape_task
 from app.tasks.comic_archive_task import comic_archive_task
 from app.tasks.comic_unarchive_task import comic_unarchive_task
 from app.tasks.comic_media_wipe_task import comic_media_wipe_task
+from app.tasks.fanfic_media_wipe_task import fanfic_media_wipe_task
 from app.tasks.cleanup_task import cleanup_task
 from app.tasks.auto_update_task import auto_update_task
 
@@ -30,7 +31,7 @@ async def shutdown(ctx: dict) -> None:
 
 
 class WorkerSettings:
-    functions = [comic_scrape_task, fanfic_scrape_task, comic_archive_task, comic_unarchive_task, comic_media_wipe_task]
+    functions = [comic_scrape_task, fanfic_scrape_task, comic_archive_task, comic_unarchive_task, comic_media_wipe_task, fanfic_media_wipe_task]
     cron_jobs = [
         cron(cleanup_task, hour=3, minute=0),           # nightly at 03:00 UTC
         cron(auto_update_task, hour={0, 6, 12, 18}, minute=0),  # every 6 hours

--- a/backend/tests/api/test_comics_permanent_route.py
+++ b/backend/tests/api/test_comics_permanent_route.py
@@ -1,0 +1,28 @@
+import uuid
+import pytest
+from tests.conftest import make_comic
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_route_returns_204(client, db_session):
+    comic = make_comic()
+    db_session.add(comic)
+    await db_session.commit()
+    comic_id = comic.id
+
+    response = await client.delete(f"/comics/{comic_id}/permanent")
+    assert response.status_code == 204
+
+    # Verify row is gone
+    from sqlalchemy import select
+    from app.models.comic import Comic
+
+    result = await db_session.execute(select(Comic).where(Comic.id == comic_id))
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_route_unknown_id_returns_204(client):
+    random_id = uuid.uuid4()
+    response = await client.delete(f"/comics/{random_id}/permanent")
+    assert response.status_code == 204  # Idempotent

--- a/backend/tests/api/test_fanfic_permanent_route.py
+++ b/backend/tests/api/test_fanfic_permanent_route.py
@@ -1,0 +1,28 @@
+import uuid
+import pytest
+from tests.conftest import make_fanfic
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_fanfic_route_returns_204(client, db_session):
+    fanfic = make_fanfic()
+    db_session.add(fanfic)
+    await db_session.commit()
+    fanfic_id = fanfic.id
+
+    response = await client.delete(f"/fanfic/{fanfic_id}/permanent")
+    assert response.status_code == 204
+
+    # Verify row is gone
+    from sqlalchemy import select
+    from app.models.fanfic import Fanfic
+
+    result = await db_session.execute(select(Fanfic).where(Fanfic.id == fanfic_id))
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_fanfic_route_unknown_id_returns_204(client):
+    random_id = uuid.uuid4()
+    response = await client.delete(f"/fanfic/{random_id}/permanent")
+    assert response.status_code == 204  # Idempotent

--- a/backend/tests/services/test_comic_service_permanent_delete.py
+++ b/backend/tests/services/test_comic_service_permanent_delete.py
@@ -2,10 +2,12 @@ import uuid
 from datetime import datetime, timezone
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, and_
 
-from tests.conftest import make_comic
+from tests.conftest import make_comic, make_progress, make_scrape_job
 from app.models.comic import Comic, ComicChapter, Page
+from app.models.progress import ReadingProgress
+from app.models.scrape import ScrapeJob
 
 
 async def _seed_comic(db_session):
@@ -70,3 +72,62 @@ async def test_permanent_delete_comic_unknown_id_is_idempotent(db_session):
     from app.services import comic_service
     result = await comic_service.permanent_delete_comic(db_session, uuid.uuid4())
     assert result is True
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_removes_polymorphic_rows_only_for_comic(db_session):
+    """Verify permanent_delete_comic deletes only its own content_type rows
+    in the polymorphic reading_progress and scrape_jobs tables — bystander
+    fanfic rows must survive."""
+    comic, _ = await _seed_comic(db_session)
+    comic_id = comic.id
+
+    # Target rows — comic-scoped polymorphic state.
+    target_progress = make_progress(content_type="comic", story_id=comic_id)
+    target_job = make_scrape_job(content_type="comic", story_id=comic_id)
+
+    # Bystander — an unrelated fanfic progress row that must NOT be touched.
+    bystander_fanfic_story_id = uuid.uuid4()
+    bystander_progress = make_progress(
+        content_type="fanfic", story_id=bystander_fanfic_story_id
+    )
+
+    db_session.add_all([target_progress, target_job, bystander_progress])
+    await db_session.commit()
+
+    from app.services import comic_service
+    result = await comic_service.permanent_delete_comic(db_session, comic_id)
+    assert result is True
+
+    # Comic-scoped reading_progress gone.
+    remaining_target_progress = (await db_session.execute(
+        select(ReadingProgress).where(
+            and_(
+                ReadingProgress.content_type == "comic",
+                ReadingProgress.story_id == comic_id,
+            )
+        )
+    )).scalars().all()
+    assert remaining_target_progress == []
+
+    # Comic-scoped scrape_jobs gone.
+    remaining_target_jobs = (await db_session.execute(
+        select(ScrapeJob).where(
+            and_(
+                ScrapeJob.content_type == "comic",
+                ScrapeJob.story_id == comic_id,
+            )
+        )
+    )).scalars().all()
+    assert remaining_target_jobs == []
+
+    # Bystander fanfic reading_progress survives.
+    remaining_bystander = (await db_session.execute(
+        select(ReadingProgress).where(
+            and_(
+                ReadingProgress.content_type == "fanfic",
+                ReadingProgress.story_id == bystander_fanfic_story_id,
+            )
+        )
+    )).scalar_one_or_none()
+    assert remaining_bystander is not None

--- a/backend/tests/services/test_comic_service_permanent_delete.py
+++ b/backend/tests/services/test_comic_service_permanent_delete.py
@@ -1,0 +1,72 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+
+from tests.conftest import make_comic
+from app.models.comic import Comic, ComicChapter, Page
+
+
+async def _seed_comic(db_session):
+    comic = make_comic()
+    db_session.add(comic)
+    await db_session.commit()
+    await db_session.refresh(comic)
+
+    chapter = ComicChapter(
+        id=uuid.uuid4(),
+        comic_id=comic.id,
+        chapter_number=1.0,
+        total_pages=2,
+        scrape_status="scraped",
+    )
+    db_session.add(chapter)
+    await db_session.commit()
+    await db_session.refresh(chapter)
+
+    for i in range(2):
+        db_session.add(Page(
+            id=uuid.uuid4(),
+            chapter_id=chapter.id,
+            page_number=i + 1,
+            file_path=f"comics/{comic.id}/{chapter.id}/page_{i + 1:04d}.jpg",
+        ))
+    await db_session.commit()
+    return comic, chapter
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_removes_all_rows(db_session):
+    comic, chapter = await _seed_comic(db_session)
+    comic_id = comic.id
+    chapter_id = chapter.id
+
+    from app.services import comic_service
+    result = await comic_service.permanent_delete_comic(db_session, comic_id)
+    assert result is True
+
+    # Parent row gone
+    remaining_comic = (await db_session.execute(
+        select(Comic).where(Comic.id == comic_id)
+    )).scalar_one_or_none()
+    assert remaining_comic is None
+
+    # Child chapters gone
+    remaining_chapters = (await db_session.execute(
+        select(ComicChapter).where(ComicChapter.comic_id == comic_id)
+    )).scalars().all()
+    assert remaining_chapters == []
+
+    # Grandchild pages gone
+    remaining_pages = (await db_session.execute(
+        select(Page).where(Page.chapter_id == chapter_id)
+    )).scalars().all()
+    assert remaining_pages == []
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_unknown_id_is_idempotent(db_session):
+    from app.services import comic_service
+    result = await comic_service.permanent_delete_comic(db_session, uuid.uuid4())
+    assert result is True

--- a/backend/tests/services/test_fanfic_service_permanent_delete.py
+++ b/backend/tests/services/test_fanfic_service_permanent_delete.py
@@ -1,0 +1,146 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select, and_
+
+from tests.conftest import make_fanfic, make_progress, make_scrape_job
+from app.models.fanfic import Fanfic, FanficChapter, FanficAuthor
+from app.models.author import Author
+from app.models.progress import ReadingProgress
+from app.models.scrape import ScrapeJob
+
+
+async def _seed_fanfic(db_session):
+    fanfic = make_fanfic()
+    db_session.add(fanfic)
+    await db_session.commit()
+    await db_session.refresh(fanfic)
+
+    chapter = FanficChapter(
+        id=uuid.uuid4(),
+        fanfic_id=fanfic.id,
+        chapter_number=1.0,
+        title="Chapter 1",
+        content="hello world",
+        word_count=2,
+        scrape_status="scraped",
+    )
+    db_session.add(chapter)
+
+    author = Author(id=uuid.uuid4(), name=f"Author {uuid.uuid4().hex[:6]}")
+    db_session.add(author)
+    await db_session.commit()
+    await db_session.refresh(author)
+
+    join = FanficAuthor(fanfic_id=fanfic.id, author_id=author.id)
+    db_session.add(join)
+    await db_session.commit()
+    await db_session.refresh(chapter)
+
+    return fanfic, chapter, author
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_fanfic_removes_all_rows(db_session):
+    fanfic, chapter, author = await _seed_fanfic(db_session)
+    fanfic_id = fanfic.id
+    chapter_id = chapter.id
+    author_id = author.id
+
+    # Polymorphic target rows — fanfic-scoped.
+    target_progress = make_progress(content_type="fanfic", story_id=fanfic_id)
+    target_job = make_scrape_job(content_type="fanfic", story_id=fanfic_id)
+
+    # Bystander comic progress row that must survive.
+    bystander_comic_story_id = uuid.uuid4()
+    bystander_progress = make_progress(
+        content_type="comic", story_id=bystander_comic_story_id
+    )
+
+    db_session.add_all([target_progress, target_job, bystander_progress])
+    await db_session.commit()
+
+    from app.services import fanfic_service
+    result = await fanfic_service.permanent_delete_fanfic(db_session, fanfic_id)
+    assert result is True
+
+    # Parent fanfic row gone.
+    remaining_fanfic = (await db_session.execute(
+        select(Fanfic).where(Fanfic.id == fanfic_id)
+    )).scalar_one_or_none()
+    assert remaining_fanfic is None
+
+    # Chapters gone.
+    remaining_chapters = (await db_session.execute(
+        select(FanficChapter).where(FanficChapter.fanfic_id == fanfic_id)
+    )).scalars().all()
+    assert remaining_chapters == []
+
+    # FanficAuthor join rows gone (but Author row itself survives — shared).
+    remaining_joins = (await db_session.execute(
+        select(FanficAuthor).where(FanficAuthor.fanfic_id == fanfic_id)
+    )).scalars().all()
+    assert remaining_joins == []
+
+    remaining_author = (await db_session.execute(
+        select(Author).where(Author.id == author_id)
+    )).scalar_one_or_none()
+    assert remaining_author is not None
+
+    # Fanfic-scoped reading_progress gone.
+    remaining_target_progress = (await db_session.execute(
+        select(ReadingProgress).where(
+            and_(
+                ReadingProgress.content_type == "fanfic",
+                ReadingProgress.story_id == fanfic_id,
+            )
+        )
+    )).scalars().all()
+    assert remaining_target_progress == []
+
+    # Fanfic-scoped scrape_jobs gone.
+    remaining_target_jobs = (await db_session.execute(
+        select(ScrapeJob).where(
+            and_(
+                ScrapeJob.content_type == "fanfic",
+                ScrapeJob.story_id == fanfic_id,
+            )
+        )
+    )).scalars().all()
+    assert remaining_target_jobs == []
+
+    # Bystander comic reading_progress survives.
+    remaining_bystander = (await db_session.execute(
+        select(ReadingProgress).where(
+            and_(
+                ReadingProgress.content_type == "comic",
+                ReadingProgress.story_id == bystander_comic_story_id,
+            )
+        )
+    )).scalar_one_or_none()
+    assert remaining_bystander is not None
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_fanfic_unknown_id_is_idempotent(db_session):
+    from app.services import fanfic_service
+    result = await fanfic_service.permanent_delete_fanfic(db_session, uuid.uuid4())
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_fanfic_cleans_fanfic_authors(db_session):
+    """Double-check: FanficAuthor join rows are cleaned up even if the
+    happy-path assertion changes in the future."""
+    fanfic, _, _ = await _seed_fanfic(db_session)
+    fanfic_id = fanfic.id
+
+    from app.services import fanfic_service
+    result = await fanfic_service.permanent_delete_fanfic(db_session, fanfic_id)
+    assert result is True
+
+    remaining_joins = (await db_session.execute(
+        select(FanficAuthor).where(FanficAuthor.fanfic_id == fanfic_id)
+    )).scalars().all()
+    assert remaining_joins == []

--- a/docs/superpowers/plans/2026-04-17-ast-19-permanent-delete-backend.md
+++ b/docs/superpowers/plans/2026-04-17-ast-19-permanent-delete-backend.md
@@ -1,0 +1,558 @@
+# AST-19 Permanent Delete — Backend Plan (PR 1 of 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan.
+
+**Goal:** Backend endpoints + services + ARQ job that hard-delete a comic/fanfic and its dependencies immediately, bypassing the 5-day soft-delete window.
+
+**Architecture:** Two new subroutes (`/permanent`) calling new `permanent_delete_*` service functions. Each function deletes dependent rows in FK-safe order, commits, invalidates Redis cache, then enqueues a best-effort media-wipe ARQ job. Idempotent: unknown ids return 204 (the iOS retry queue depends on this).
+
+**Tech Stack:** FastAPI, SQLAlchemy async, ARQ, Redis, pytest. Run locally via `docker-compose.local.yml`.
+
+**Spec:** [docs/superpowers/specs/2026-04-17-ast-19-permanent-delete-design.md](../specs/2026-04-17-ast-19-permanent-delete-design.md)
+
+**Branch:** `feature/ast-19-permanent-delete-backend` (off `origin/development`, already checked out)
+
+**Scope note:** This PR ships backend-only. The iOS client continues to use the existing soft-delete endpoint until PR 2 lands. Deploying this PR is safe — no breaking change.
+
+---
+
+### Task 1: Inspect FK constraints and existing delete paths
+
+**Files:**
+- Read: `backend/app/models/comic.py`, `backend/app/models/fanfic.py`, `backend/app/models/scrape.py`, `backend/app/models/progress.py`
+
+- [ ] **Step 1: Document the FK graph**
+
+Read each model file, note every `ForeignKey`, `relationship`, and `ondelete` directive that involves `Comic`, `ComicChapter`, `Page`, `Fanfic`, `FanficChapter`, `ScrapeJob`, `ReadingProgress`.
+
+Produce (as plain notes in your head or a scratch pad — no file needed) the FK order required for hard-delete. Expected, per the spec:
+- Comic: `Page` → `ComicChapter` → `ScrapeJob (content='comic')` → `ReadingProgress (comic_id)` → `Comic`.
+- Fanfic: `FanficChapter` → `ScrapeJob (content='fanfic')` → `ReadingProgress (fanfic_id?)` → `Fanfic`.
+
+Confirm whether any FK already has `ondelete="CASCADE"` — if so, you can skip the manual child delete. The spec's explicit delete order is a safe default.
+
+- [ ] **Step 2: Confirm media paths**
+
+Grep `backend/app/services/comic_service.py` for directory patterns: `astral-media`, `/mnt/`, `comics/{comic_id}`. Note the exact path format used by the thumbnail/page save code.
+
+Grep `fanfic_service.py` similarly. If fanfic has no page-storage (only thumbnails), the fanfic media-wipe job is just a thumbnail delete.
+
+- [ ] **Step 3: No commit**
+
+This task is read-only. Just understand the graph before writing code.
+
+---
+
+### Task 2: Implement `permanent_delete_comic` service + ARQ media-wipe task
+
+**Files:**
+- Modify: `backend/app/services/comic_service.py`
+- Create: `backend/app/tasks/comic_media_wipe_task.py`
+- Modify: `backend/app/worker/worker.py` (or wherever the ARQ task list is registered — find it via `grep -rn "auto_update_task\|cleanup_task" backend/app/worker`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/services/test_comic_service_permanent_delete.py`:
+
+```python
+import pytest
+import uuid
+from app.services.comic_service import permanent_delete_comic
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_removes_rows_and_returns_true(db_session, seeded_comic):
+    # seeded_comic fixture should create a Comic with 1 chapter and 2 pages
+    comic_id = seeded_comic.id
+
+    result = await permanent_delete_comic(db_session, comic_id)
+    assert result is True
+
+    # Verify all rows gone
+    from app.models.comic import Comic, ComicChapter, Page
+    from sqlalchemy import select
+    assert (await db_session.execute(select(Comic).where(Comic.id == comic_id))).scalar_one_or_none() is None
+    assert (await db_session.execute(select(ComicChapter).where(ComicChapter.comic_id == comic_id))).scalars().all() == []
+    # Pages are FK'd to chapters; if chapters gone, pages should be too
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_unknown_id_returns_true(db_session):
+    random_id = uuid.uuid4()
+    result = await permanent_delete_comic(db_session, random_id)
+    assert result is True  # Idempotent
+```
+
+Check `backend/tests/conftest.py` for existing fixtures (`db_session`, `seeded_comic` may need to be added — match the pattern of other service tests under `backend/tests/services/`). If no equivalent fixture exists, add a minimal one inline in the test file.
+
+- [ ] **Step 2: Run the test, confirm it fails**
+
+```bash
+cd backend && docker compose -f docker-compose.local.yml exec backend pytest tests/services/test_comic_service_permanent_delete.py -v
+```
+
+Expected: `AttributeError: module 'app.services.comic_service' has no attribute 'permanent_delete_comic'` or similar.
+
+- [ ] **Step 3: Implement `permanent_delete_comic`**
+
+In `backend/app/services/comic_service.py`, add after `soft_delete_comic` (around line 291):
+
+```python
+async def permanent_delete_comic(db: AsyncSession, comic_id: uuid.UUID) -> bool:
+    """Hard-delete a comic and all its dependent rows. Idempotent."""
+    logger.info("permanent_delete_comic called | comic_id=%s", comic_id)
+
+    # Delete in FK order: pages → chapters → scrape jobs → reading progress → comic
+    await db.execute(
+        delete(Page).where(
+            Page.chapter_id.in_(select(ComicChapter.id).where(ComicChapter.comic_id == comic_id))
+        )
+    )
+    await db.execute(delete(ComicChapter).where(ComicChapter.comic_id == comic_id))
+    await db.execute(
+        delete(ScrapeJob).where(
+            and_(ScrapeJob.story_id == comic_id, ScrapeJob.content_type == "comic")
+        )
+    )
+    # ReadingProgress: column name and presence vary — verify and include if applicable
+    # await db.execute(delete(ReadingProgress).where(ReadingProgress.comic_id == comic_id))
+    await db.execute(delete(Comic).where(Comic.id == comic_id))
+    await db.commit()
+
+    await redis_cache.invalidate_comics(str(comic_id))
+
+    # Best-effort media wipe
+    try:
+        import arq
+        from app.core.config import settings
+        arq_redis = await arq.create_pool(settings.arq_redis_settings)
+        await arq_redis.enqueue_job("comic_media_wipe_task", str(comic_id))
+        await arq_redis.aclose()
+    except Exception as e:
+        logger.warning("permanent_delete_comic ARQ enqueue failed | comic_id=%s error=%s", comic_id, e)
+
+    return True
+```
+
+Add the required imports at the top of the file (match existing style):
+
+```python
+from sqlalchemy import delete, select, and_
+from app.models.comic import Comic, ComicChapter, Page
+from app.models.scrape import ScrapeJob
+```
+
+(The specific `ReadingProgress` column name depends on Task 1 Step 1's findings — include the delete only if the comic has a direct FK to it. If reading progress cascades via chapter/comic on delete, skip this line.)
+
+- [ ] **Step 4: Create the ARQ job**
+
+Create `backend/app/tasks/comic_media_wipe_task.py`:
+
+```python
+import logging
+import shutil
+from pathlib import Path
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def comic_media_wipe_task(ctx, comic_id: str):
+    """Best-effort: delete /mnt/astral-media/comics/{comic_id}/. Never raises."""
+    media_root = Path(settings.astral_media_root if hasattr(settings, "astral_media_root") else "/mnt/astral-media")
+    target = media_root / "comics" / comic_id
+    try:
+        shutil.rmtree(target, ignore_errors=True)
+        logger.info("comic_media_wipe_task done | comic_id=%s target=%s", comic_id, target)
+    except Exception as e:
+        logger.warning("comic_media_wipe_task failed | comic_id=%s error=%s", comic_id, e)
+```
+
+Verify the settings path key by grep: `grep -rn "astral_media\|media_root" backend/app/core/config.py`. If the key has a different name, substitute.
+
+- [ ] **Step 5: Register the ARQ task**
+
+Find the ARQ worker config (likely `backend/app/worker/worker.py` or similar — use `grep -rn "functions.*=.*\[" backend/app/worker/`). Add `comic_media_wipe_task` to the `functions` list, imported at top of the file:
+
+```python
+from app.tasks.comic_media_wipe_task import comic_media_wipe_task
+# ...
+functions = [
+    cleanup_task,
+    auto_update_task,
+    comic_scrape_task,
+    fanfic_scrape_task,
+    comic_archive_task,
+    comic_unarchive_task,
+    comic_media_wipe_task,  # NEW
+]
+```
+
+- [ ] **Step 6: Run the test, confirm it passes**
+
+```bash
+cd backend && docker compose -f docker-compose.local.yml exec backend pytest tests/services/test_comic_service_permanent_delete.py -v
+```
+
+Expected: `PASSED` on both test cases.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/comic_service.py \
+        backend/app/tasks/comic_media_wipe_task.py \
+        backend/app/worker/worker.py \
+        backend/tests/services/test_comic_service_permanent_delete.py
+git commit -m "[backend] AST-19 permanent_delete_comic service + media wipe task
+
+Hard-delete comic + chapters + pages + scrape jobs in FK-safe order,
+commit, invalidate Redis cache, enqueue best-effort media wipe ARQ
+job. Idempotent: unknown comic_id returns True so the iOS retry queue
+can drain safely.
+
+New ARQ task comic_media_wipe_task: rmtree /mnt/astral-media/comics/{id}
+with ignore_errors=True. Registered in worker functions list."
+```
+
+---
+
+### Task 3: Implement `permanent_delete_fanfic` service + ARQ job
+
+Mirror of Task 2 for fanfic. Same structure, different models.
+
+**Files:**
+- Modify: `backend/app/services/fanfic_service.py`
+- Create: `backend/app/tasks/fanfic_media_wipe_task.py` (only if fanfic has a media directory; otherwise skip this file and do the thumbnail delete inline in the service)
+- Modify: `backend/app/worker/worker.py` (register the new task if created)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/services/test_fanfic_service_permanent_delete.py` mirroring the comic test. Adjust models: `Fanfic`, `FanficChapter`, no `Page` (fanfic content is stored inline, not as separate page rows — confirm via Task 1's notes).
+
+- [ ] **Step 2: Run test, confirm failure**
+
+```bash
+cd backend && docker compose -f docker-compose.local.yml exec backend pytest tests/services/test_fanfic_service_permanent_delete.py -v
+```
+
+Expected: `AttributeError` on `permanent_delete_fanfic`.
+
+- [ ] **Step 3: Implement `permanent_delete_fanfic`**
+
+In `backend/app/services/fanfic_service.py`, after `soft_delete_fanfic` (around line 180):
+
+```python
+async def permanent_delete_fanfic(db: AsyncSession, fanfic_id: uuid.UUID) -> bool:
+    """Hard-delete a fanfic and dependent rows. Idempotent."""
+    logger.info("permanent_delete_fanfic called | fanfic_id=%s", fanfic_id)
+
+    await db.execute(delete(FanficChapter).where(FanficChapter.fanfic_id == fanfic_id))
+    await db.execute(
+        delete(ScrapeJob).where(
+            and_(ScrapeJob.story_id == fanfic_id, ScrapeJob.content_type == "fanfic")
+        )
+    )
+    # ReadingProgress: verify column name and include if applicable
+    await db.execute(delete(Fanfic).where(Fanfic.id == fanfic_id))
+    await db.commit()
+
+    await redis_cache.invalidate_fanfic(str(fanfic_id))  # Verify method name
+
+    # Best-effort media wipe (thumbnail only for fanfic — no page directory)
+    try:
+        import arq
+        from app.core.config import settings
+        arq_redis = await arq.create_pool(settings.arq_redis_settings)
+        await arq_redis.enqueue_job("fanfic_media_wipe_task", str(fanfic_id))
+        await arq_redis.aclose()
+    except Exception as e:
+        logger.warning("permanent_delete_fanfic ARQ enqueue failed | fanfic_id=%s error=%s", fanfic_id, e)
+
+    return True
+```
+
+Add imports mirroring the comic version.
+
+- [ ] **Step 4: Create the ARQ job** (only if fanfic has a media dir; otherwise inline the thumbnail delete in the service and skip this step)
+
+Create `backend/app/tasks/fanfic_media_wipe_task.py`:
+
+```python
+import logging
+from pathlib import Path
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+async def fanfic_media_wipe_task(ctx, fanfic_id: str):
+    """Best-effort: delete fanfic thumbnail(s). Never raises."""
+    media_root = Path(settings.astral_media_root if hasattr(settings, "astral_media_root") else "/mnt/astral-media")
+    # Match existing fanfic thumbnail path convention (verify from fanfic_service save code)
+    thumbnail = media_root / "fanfics" / f"{fanfic_id}.jpg"
+    try:
+        thumbnail.unlink(missing_ok=True)
+        logger.info("fanfic_media_wipe_task done | fanfic_id=%s", fanfic_id)
+    except Exception as e:
+        logger.warning("fanfic_media_wipe_task failed | fanfic_id=%s error=%s", fanfic_id, e)
+```
+
+- [ ] **Step 5: Register the ARQ task**
+
+Add `fanfic_media_wipe_task` to the `functions` list in `backend/app/worker/worker.py`.
+
+- [ ] **Step 6: Run test, confirm pass**
+
+```bash
+cd backend && docker compose -f docker-compose.local.yml exec backend pytest tests/services/test_fanfic_service_permanent_delete.py -v
+```
+
+Expected: `PASSED`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/services/fanfic_service.py \
+        backend/app/tasks/fanfic_media_wipe_task.py \
+        backend/app/worker/worker.py \
+        backend/tests/services/test_fanfic_service_permanent_delete.py
+git commit -m "[backend] AST-19 permanent_delete_fanfic service + media wipe task
+
+Mirror of comic permanent-delete. Hard-delete fanfic + chapters +
+scrape jobs, invalidate Redis cache, enqueue best-effort thumbnail
+wipe. Idempotent."
+```
+
+---
+
+### Task 4: Add `/permanent` routes
+
+**Files:**
+- Modify: `backend/app/api/v1/routes/comics.py`
+- Modify: `backend/app/api/v1/routes/fanfic.py`
+
+- [ ] **Step 1: Write route tests**
+
+Create `backend/tests/routes/test_comic_permanent_route.py`:
+
+```python
+import pytest
+import uuid
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_route_returns_204(async_client, seeded_comic):
+    response = await async_client.delete(f"/api/v1/comics/{seeded_comic.id}/permanent")
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_permanent_delete_comic_route_unknown_id_returns_204(async_client):
+    random_id = uuid.uuid4()
+    response = await async_client.delete(f"/api/v1/comics/{random_id}/permanent")
+    assert response.status_code == 204  # Idempotent
+```
+
+Check `backend/tests/routes/` for existing route-test conventions (fixture names may differ — look at `test_comics_route.py` if one exists). Create `backend/tests/routes/test_fanfic_permanent_route.py` mirroring the comic one.
+
+- [ ] **Step 2: Run tests, confirm 404 / fail**
+
+```bash
+cd backend && docker compose -f docker-compose.local.yml exec backend pytest tests/routes/test_comic_permanent_route.py tests/routes/test_fanfic_permanent_route.py -v
+```
+
+Expected: route returns 405 Method Not Allowed or 404 (the route doesn't exist yet).
+
+- [ ] **Step 3: Add comic route**
+
+In `backend/app/api/v1/routes/comics.py`, after the existing `delete_comic` at line 68-72, add:
+
+```python
+@router.delete("/{comic_id}/permanent", status_code=204)
+async def permanent_delete_comic_route(comic_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    await comic_service.permanent_delete_comic(db, comic_id)
+    # Idempotent: always 204, even for unknown ids
+```
+
+- [ ] **Step 4: Add fanfic route**
+
+In `backend/app/api/v1/routes/fanfic.py`, after the existing `delete_fanfic` at line 49-53:
+
+```python
+@router.delete("/{fanfic_id}/permanent", status_code=204)
+async def permanent_delete_fanfic_route(fanfic_id: uuid.UUID, db: AsyncSession = Depends(get_db)):
+    await fanfic_service.permanent_delete_fanfic(db, fanfic_id)
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+```bash
+cd backend && docker compose -f docker-compose.local.yml exec backend pytest tests/routes/test_comic_permanent_route.py tests/routes/test_fanfic_permanent_route.py -v
+```
+
+Expected: both test files pass (4 cases).
+
+- [ ] **Step 6: Full backend test sweep**
+
+```bash
+cd backend && docker compose -f docker-compose.local.yml exec backend pytest -x
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/app/api/v1/routes/comics.py \
+        backend/app/api/v1/routes/fanfic.py \
+        backend/tests/routes/test_comic_permanent_route.py \
+        backend/tests/routes/test_fanfic_permanent_route.py
+git commit -m "[backend] AST-19 DELETE /permanent routes for comic and fanfic
+
+Both routes call the new permanent_delete_* service and return 204,
+regardless of whether the target row existed (idempotent). iOS retry
+queue depends on 204-for-unknown-id behavior."
+```
+
+---
+
+### Task 5: Integration test — hit a live dev backend
+
+- [ ] **Step 1: Start the local stack**
+
+```bash
+cd backend && docker compose -f docker-compose.local.yml up -d
+```
+
+Wait ~10s for backend + worker + db to be ready. Verify with `curl http://localhost:8000/api/v1/health`.
+
+- [ ] **Step 2: Seed a throwaway comic via the API**
+
+```bash
+# If there's an existing script or curl pattern for creating a comic via scrape,
+# use it. Otherwise, query an existing comic id from the DB:
+docker compose -f docker-compose.local.yml exec backend python -c "
+from app.db.database import AsyncSessionLocal
+from app.models.comic import Comic
+from sqlalchemy import select
+import asyncio
+
+async def main():
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(Comic).limit(1))
+        comic = result.scalar_one_or_none()
+        print(comic.id if comic else 'NO COMIC')
+asyncio.run(main())
+"
+```
+
+Note the returned UUID.
+
+- [ ] **Step 3: Hit the permanent-delete endpoint**
+
+```bash
+curl -v -X DELETE "http://localhost:8000/api/v1/comics/{UUID}/permanent"
+```
+
+Expected: `HTTP/1.1 204 No Content`.
+
+- [ ] **Step 4: Verify DB state**
+
+```bash
+docker compose -f docker-compose.local.yml exec postgres psql -U astral -d astral -c "SELECT COUNT(*) FROM comics WHERE id = '{UUID}';"
+```
+
+Expected: `count = 0`.
+
+Same for chapters:
+
+```bash
+docker compose -f docker-compose.local.yml exec postgres psql -U astral -d astral -c "SELECT COUNT(*) FROM comic_chapters WHERE comic_id = '{UUID}';"
+```
+
+Expected: `count = 0`.
+
+- [ ] **Step 5: Verify idempotency**
+
+Run the `curl` again with the same UUID.
+
+Expected: `HTTP/1.1 204 No Content` (not 404).
+
+- [ ] **Step 6: Verify media wipe fired (best-effort)**
+
+Check worker logs:
+
+```bash
+docker compose -f docker-compose.local.yml logs arq_worker | grep "comic_media_wipe"
+```
+
+Expected: a log line per invocation. If media root had files, verify they're gone: `docker compose -f docker-compose.local.yml exec backend ls /mnt/astral-media/comics/{UUID} 2>&1` — expected "No such file or directory."
+
+- [ ] **Step 7: If any check fails**
+
+Stop. Describe symptom and return to the failing task.
+
+---
+
+### Task 6: Push branch and open PR
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin feature/ast-19-permanent-delete-backend
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --base development --title "[backend] AST-19 permanent delete endpoints (comic + fanfic)" --body "$(cat <<'EOF'
+## Summary
+
+First of two PRs for AST-19. Backend-only.
+
+- New `DELETE /api/v1/comics/{id}/permanent` and `DELETE /api/v1/fanfic/{id}/permanent` routes.
+- New `permanent_delete_comic` / `permanent_delete_fanfic` services: hard-delete the row + dependent children in FK-safe order, invalidate Redis cache, enqueue best-effort media-wipe ARQ job.
+- New `comic_media_wipe_task` / `fanfic_media_wipe_task` ARQ jobs.
+- Existing soft-delete endpoints and `cleanup_task` cron unchanged.
+- Idempotent: unknown ids return 204 (iOS retry queue depends on this).
+
+Part of [AST-19](https://linear.app/nnetraganti/issue/AST-19/library-add-permanent-delete-long-press-on-library-item-and-action-in). iOS wiring lands in a follow-up PR after this ships.
+
+Spec: `docs/superpowers/specs/2026-04-17-ast-19-permanent-delete-design.md`
+
+## Test plan
+
+- [x] Unit tests for both services (happy path + unknown-id idempotent path)
+- [x] Route tests for both endpoints
+- [x] Full `pytest -x` sweep passes
+- [x] Integration: `curl -X DELETE` against live dev backend returns 204, DB rows are gone, worker logs show media wipe task fired, second call to same id also returns 204
+
+## Deploy note
+
+This PR can ship independently. No iOS client needs updating — the existing soft-delete endpoints continue to work. PR 2 (iOS) will only merge once this is deployed.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report PR URL**
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- New routes → Task 4 ✓
+- Service hard-delete in FK order → Tasks 2, 3 ✓
+- Redis cache invalidation → Tasks 2, 3 ✓
+- ARQ media wipe → Tasks 2, 3 ✓
+- Idempotent 204 for unknown ids → Tasks 2, 4 ✓
+- Keep soft-delete path working → Tasks 2, 3, 4 (no change to existing endpoints) ✓
+
+**Placeholder scan:** none that aren't explicit "verify during implementation" instructions (FK cascade behavior, settings key names, fixture names). Each verification has a concrete grep/check to run.
+
+**Known sharp edges:**
+- Worker file location may not be `backend/app/worker/worker.py` — Task 2 Step 5 includes the grep to find it.
+- `ReadingProgress` column name depends on the model — Task 1 Step 1's FK graph feeds Task 2's implementation.
+- `arq_redis_settings` key on `settings` — verify via `grep arq_redis backend/app/core/config.py`. If different, substitute.

--- a/docs/superpowers/plans/2026-04-17-ast-19-permanent-delete-backend.md
+++ b/docs/superpowers/plans/2026-04-17-ast-19-permanent-delete-backend.md
@@ -14,6 +14,67 @@
 
 **Scope note:** This PR ships backend-only. The iOS client continues to use the existing soft-delete endpoint until PR 2 lands. Deploying this PR is safe — no breaking change.
 
+## Corrections discovered during Task 1 FK inspection (applied throughout)
+
+The spec got several backend details wrong; Task 1 verified the real state of the codebase. Any task in this plan that conflicts with the items below should follow the Task 1 findings:
+
+1. **Worker file is `backend/app/worker.py` (flat module), not `backend/app/worker/worker.py`.** The `WorkerSettings` class has `functions = [comic_scrape_task, fanfic_scrape_task, comic_archive_task, comic_unarchive_task]`. New tasks go in `functions` (event-driven), not `cron_jobs`.
+2. **ARQ pool pattern is NOT `arq.create_pool(settings.arq_redis_settings)`** — there is no such setting. Use the existing enqueue pattern from `comic_service.archive_comic` (lines 242-245):
+   ```python
+   import redis.asyncio as aioredis
+   from arq.connections import ArqRedis
+   r = await aioredis.from_url(settings.redis_url)
+   arq_redis = ArqRedis(r.connection_pool)
+   await arq_redis.enqueue_job("task_name", arg1)
+   await arq_redis.aclose()
+   ```
+3. **Media root setting key is `settings.block_volume_path`** (default `/tmp/astral-media`, prod env overrides to `/mnt/astral-media`). There is no `astral_media_root` key.
+4. **FK cascades are NOT configured** — every child delete is explicit. No `ondelete="CASCADE"` anywhere.
+5. **Polymorphic association tables:** `reading_progress` and `scrape_jobs` use `content_type` (string) + `story_id` (uuid) — no FK from them to `comics`/`fanfics`. Delete with `WHERE content_type='comic' AND story_id=:id`.
+6. **Additional tables to purge** that the spec missed:
+   - `comic_authors` (join), `comic_tags` (join) — for comic permanent delete.
+   - `fanfic_authors` (join) — for fanfic permanent delete.
+   - `reading_progress` (polymorphic) — both.
+7. **Archived comics** have media at `{block_volume_path}/archive/comics/{id}/` instead of `{block_volume_path}/comics/{id}/`. The media-wipe task must handle both paths (rmtree both with `ignore_errors=True`).
+8. **Fanfic has NO page table** — chapter body is inline on `fanfic_chapters.content`. No media directory for fanfic pages; only a shared pool of random thumbnail covers (don't delete those).
+9. **FK from `comics.scrape_job_id` to `scrape_jobs.id`** means the comic row MUST be deleted before the scrape_jobs row (or null the FK first). The delete order below respects this.
+10. **No cleanup of `scrape_logs`** today — orphans accumulate already. Optional follow-up; skip for this PR.
+
+## Corrected DELETE order
+
+**Comic:**
+1. `pages WHERE chapter_id IN (SELECT id FROM comic_chapters WHERE comic_id=:id)`
+2. `comic_chapters WHERE comic_id=:id`
+3. `comic_authors WHERE comic_id=:id`
+4. `comic_tags WHERE comic_id=:id`
+5. `reading_progress WHERE content_type='comic' AND story_id=:id`
+6. `comics WHERE id=:id`
+7. `scrape_jobs WHERE content_type='comic' AND story_id=:id`  — AFTER comic (FK from comics.scrape_job_id)
+
+**Fanfic:**
+1. `fanfic_chapters WHERE fanfic_id=:id`
+2. `fanfic_authors WHERE fanfic_id=:id`
+3. `reading_progress WHERE content_type='fanfic' AND story_id=:id`
+4. `fanfics WHERE id=:id`
+5. `scrape_jobs WHERE content_type='fanfic' AND story_id=:id`
+
+## Running pytest (critical)
+
+The `backend-fastapi-1` container's image does NOT include `pytest` or the `tests/` directory. For test execution in this worktree, the harness has been prepped:
+- `pytest==8.3.3`, `pytest-asyncio==0.24.0`, `aiosqlite==0.20.0`, `httpx==0.27.2` are installed in the running container.
+- `backend/tests/` and `backend/pytest.ini` have been copied into `/app/tests` and `/app/pytest.ini` via `docker cp`.
+
+**When you add a NEW test file**, you MUST copy it into the container before running pytest:
+
+```bash
+docker cp backend/tests/services/<new_file>.py backend-fastapi-1:/app/tests/services/
+docker exec -w /app backend-fastapi-1 pytest tests/services/<new_file>.py -v
+```
+
+**Do NOT use** `docker compose -f docker-compose.local.yml exec backend pytest ...` (the plan's original text). The service name in compose is `fastapi`, not `backend`, and pytest isn't on the image PATH by default.
+
+**Pre-existing test failures to ignore:** 4 tests fail on `development` unrelated to this work — `test_update_comic_title`, `test_update_comic_thumbnail`, `test_update_comic_partial_fields`, `test_soft_delete_comic_hides_from_list`. Do not try to fix them; do not let them block a green run for new tests you add.
+
 ---
 
 ### Task 1: Inspect FK constraints and existing delete paths

--- a/docs/superpowers/specs/2026-04-17-ast-19-permanent-delete-design.md
+++ b/docs/superpowers/specs/2026-04-17-ast-19-permanent-delete-design.md
@@ -1,0 +1,257 @@
+# AST-19 — Permanent delete: library + detail view entry points
+
+Linear: [AST-19](https://linear.app/nnetraganti/issue/AST-19/library-add-permanent-delete-long-press-on-library-item-and-action-in)
+
+## Problem
+
+Users have no way to permanently delete a story. The library's existing context-menu "Delete" action silently soft-deletes via `DELETE /comics/{id}` / `DELETE /fanfic/{id}` (both map to `soft_delete_*` which sets `deleted_at` and waits for the nightly `cleanup_task` to hard-purge after `SOFT_DELETE_DAYS=5`). Two gaps:
+
+1. Local SwiftData state is not deleted on the iOS side — only the backend row is soft-marked.
+2. The user has no UI that says "delete this now, permanently, with confirmation."
+3. Bookmarks, reading sessions, scrape jobs, and downloaded files on disk are never cleaned up by the existing soft-delete path.
+
+## Goal
+
+Two entry points — library context menu (replace existing silent "Delete") and detail-view toolbar overflow — both gated by an `.alert` confirmation. On confirm, the story is purged immediately from local SwiftData, local filesystem, and the backend database + media store. Offline behavior: local purge happens immediately; remote call is retried via a persisted pending-deletion queue when connectivity returns.
+
+## Scope
+
+This spec covers both backend and iOS. **Shipped as two PRs:**
+
+1. **PR 1 (backend-first)** — new `/permanent` routes, `permanent_delete_*` services, ARQ media-wipe job. Merged and deployed before PR 2.
+2. **PR 2 (iOS)** — `StoryDeletionService`, `PendingRemoteDeletion` @Model, shared confirmation alert, library + detail view wiring, launch-time drain.
+
+## Design
+
+### Backend (PR 1)
+
+#### New routes
+
+- `DELETE /api/v1/comics/{comic_id}/permanent` → `comic_service.permanent_delete_comic`
+- `DELETE /api/v1/fanfic/{fanfic_id}/permanent` → `fanfic_service.permanent_delete_fanfic`
+
+Each returns `204 No Content` on success. **Idempotent:** if the story is already gone, return 204 (not 404). The client's retry queue depends on this.
+
+#### Service behavior
+
+`permanent_delete_comic(db, comic_id)`:
+
+1. Hard-delete (`DELETE FROM ...`) rows in this order to respect FKs:
+   - `Page WHERE chapter_id IN (SELECT id FROM comic_chapters WHERE comic_id = :id)`
+   - `ComicChapter WHERE comic_id = :id`
+   - `ScrapeJob WHERE story_id = :id AND content_type = 'comic'`
+   - `ReadingProgress WHERE comic_id = :id` (if applicable — verify column name)
+   - `Comic WHERE id = :id`
+2. `await db.commit()`.
+3. Invalidate Redis cache: `await redis_cache.invalidate_comics(str(comic_id))`.
+4. Enqueue ARQ job `comic_media_wipe_task` with `{comic_id: str}` to delete `/mnt/astral-media/comics/{comic_id}/` (the chapter page directories + the thumbnail).
+5. Return `True`. If the Comic row didn't exist at step 1, return `True` anyway (idempotent — caller returns 204).
+
+`permanent_delete_fanfic(db, fanfic_id)` mirrors the above with: `FanficChapter` → `ScrapeJob (content_type='fanfic')` → `ReadingProgress` → `Fanfic`. Thumbnail wipe targets `/mnt/astral-media/fanfics/{fanfic_id}/` if anything is stored there (scan `fanfic_service` to confirm — fanfic currently has no downloaded page store, only thumbnails).
+
+**Author rows (`Author`) are NEVER touched** — they're shared across stories.
+
+#### New ARQ job — `comic_media_wipe_task`
+
+- Arg: `comic_id: str`.
+- Body: `shutil.rmtree("/mnt/astral-media/comics/{comic_id}", ignore_errors=True)`; best-effort single-file delete of the thumbnail at its stored path.
+- Log success/failure; never raise (this is best-effort, idempotent).
+- Registered in `app/worker/worker.py` (or wherever the existing ARQ task list lives).
+
+A separate `fanfic_media_wipe_task` for fanfic if/when there are any media artifacts; if only thumbnails, keep it minimal.
+
+#### Keep the existing soft-delete path
+
+`DELETE /comics/{id}` and `DELETE /fanfic/{id}` continue to call `soft_delete_*` unchanged. This preserves compatibility with any out-of-band caller (admin tool, old iOS clients). The `cleanup_task` nightly cron stays as-is.
+
+### iOS (PR 2)
+
+#### New service — `StoryDeletionService`
+
+Location: `ios/Astral/Packages/Core/Sources/Core/Services/StoryDeletionService.swift`.
+
+`@MainActor final class StoryDeletionService` with `static let shared`.
+
+```swift
+func permanentlyDelete(comic: LocalComic, chapters: [LocalComicChapter], modelContext: ModelContext) async
+func permanentlyDelete(fanfic: LocalFanfic, modelContext: ModelContext) async
+```
+
+**Each method (common skeleton):**
+
+1. Capture `id = comic.id` (or `fanfic.id`) up front — the SwiftData object becomes invalid after deletion.
+2. Local purge (always runs, even if remote fails):
+   a. `ChapterDownloadService.shared.deleteAllChapters(comic:chapters:modelContext:)` (for comics) or `FanficDownloadService.shared.deleteAllChapters(fanfic:modelContext:)` (for fanfics).
+   b. Fetch + delete `LocalBookmark` rows matching `storyId == id && contentType == "comic"|"fanfic"` via `ModelContext.fetch(FetchDescriptor(predicate:))`.
+   c. Fetch + delete `LocalReadingSession` rows same predicate.
+   d. Fetch + delete `LocalScrapeJob` rows matching `storyId == id`.
+   e. `modelContext.delete(comic)` — SwiftData cascades the chapter rows via the existing `comic: LocalComic?` relationship.
+   f. `try? modelContext.save()`.
+3. Remote call:
+   a. `try await APIClient.shared.requestVoid(.permanentDeleteComic(id: id))`.
+   b. On success: done.
+   c. On throw: insert `PendingRemoteDeletion(id: id, contentType: "comic", createdAt: .now)` into `modelContext`, `try? modelContext.save()`. Log `AstralLogger.warning`.
+
+#### New @Model — `PendingRemoteDeletion`
+
+Location: `ios/Astral/Packages/Core/Sources/Core/Models/PendingRemoteDeletion.swift`.
+
+```swift
+@Model
+public final class PendingRemoteDeletion {
+    @Attribute(.unique) public var id: UUID
+    public var storyId: UUID
+    public var contentType: String  // "comic" | "fanfic"
+    public var createdAt: Date
+
+    public init(storyId: UUID, contentType: String) {
+        self.id = UUID()
+        self.storyId = storyId
+        self.contentType = contentType
+        self.createdAt = .now
+    }
+}
+```
+
+Register in `AstralApp.swift`'s `Schema([...])`.
+
+#### Launch-time drain
+
+In `AstralApp.swift`, after the existing `OrphanCleanupService` pass, add a call to `PendingDeletionDrainService.drain(modelContext:)` (new small helper). This service:
+
+1. Fetches all `PendingRemoteDeletion` rows.
+2. For each, calls the appropriate `APIClient.requestVoid(.permanentDelete*(id:))`.
+3. On success or 404 (idempotent), deletes the `PendingRemoteDeletion` row.
+4. On network failure, leaves the row alone for the next launch.
+5. `try? modelContext.save()`.
+
+Runs once per launch; fire-and-forget from a `Task { @MainActor in ... }`.
+
+#### New endpoints in `Networking`
+
+In `ios/Astral/Packages/Networking/Sources/Networking/Endpoints.swift`, add:
+
+```swift
+case permanentDeleteComic(id: UUID)
+case permanentDeleteFanfic(id: UUID)
+```
+
+Both `method: .delete`, path `/api/v1/comics/{id}/permanent` / `/api/v1/fanfic/{id}/permanent`.
+
+#### UI — shared confirmation alert
+
+Location: `ios/Astral/Packages/DesignSystem/Sources/DesignSystem/DeletePermanentlyAlert.swift`.
+
+A `ViewModifier` or computed `View` that takes a binding + title + action closure:
+
+```swift
+public struct DeletePermanentlyAlertModifier: ViewModifier {
+    @Binding public var isPresented: Bool
+    public let storyTitle: String
+    public let onConfirm: () -> Void
+
+    public func body(content: Content) -> some View {
+        content.alert("Delete Permanently?", isPresented: $isPresented) {
+            Button("Cancel", role: .cancel) { }
+            Button("Delete", role: .destructive) { onConfirm() }
+        } message: {
+            Text("This will permanently delete \"\(storyTitle)\" and all local data. This cannot be undone.")
+        }
+    }
+}
+
+public extension View {
+    func deletePermanentlyAlert(
+        isPresented: Binding<Bool>,
+        storyTitle: String,
+        onConfirm: @escaping () -> Void
+    ) -> some View {
+        modifier(DeletePermanentlyAlertModifier(isPresented: isPresented, storyTitle: storyTitle, onConfirm: onConfirm))
+    }
+}
+```
+
+#### Library context menus
+
+- `FanficLibraryView.swift`: inside the existing `.contextMenu { ... }`, **replace** the current destructive "Delete" button (which calls `deleteFanfic(...)`) with a new button:
+
+  ```swift
+  Button(role: .destructive) {
+      pendingDeletion = fanfic
+  } label: {
+      Label("Delete permanently", systemImage: "trash.slash")
+  }
+  ```
+
+  Add view state: `@State private var pendingDeletion: LocalFanfic?`.
+
+  Add the alert modifier on the ScrollView:
+
+  ```swift
+  .deletePermanentlyAlert(
+      isPresented: Binding(get: { pendingDeletion != nil }, set: { if !$0 { pendingDeletion = nil } }),
+      storyTitle: pendingDeletion?.title ?? "",
+      onConfirm: {
+          if let fanfic = pendingDeletion {
+              Task { await StoryDeletionService.shared.permanentlyDelete(fanfic: fanfic, modelContext: modelContext) }
+          }
+          pendingDeletion = nil
+      }
+  )
+  ```
+
+  Remove the old `deleteFanfic(_:)` helper (no longer used). If the helper has callers besides the context menu, repoint or leave untouched (audit during implementation).
+
+- `ComicLibraryView.swift`: same pattern. Keep the existing "Archive" / "Unarchive" items; only replace "Delete" with "Delete permanently."
+
+#### Detail view toolbar
+
+- `FanficDetailView.swift`: add a trailing toolbar button with `Menu { ... } label: { Image(systemName: "ellipsis.circle") }` containing a single destructive "Delete permanently" item that sets a local `@State showDeleteAlert: Bool`. On confirm, call `StoryDeletionService.shared.permanentlyDelete(fanfic:modelContext:)`, then dismiss the detail view.
+
+- `ComicDetailView.swift`: same pattern.
+
+**Navigation after successful deletion:** in the detail view's confirm handler, dismiss the view (`@Environment(\.dismiss) var dismiss`) so the user returns to the library, where the just-deleted story is already gone from `@Query`.
+
+#### Haptics
+
+None custom. SwiftUI's `.contextMenu` provides the long-press haptic; `.alert` provides the confirmation feedback.
+
+## Acceptance
+
+### Backend
+
+- `curl -X DELETE http://localhost:8000/api/v1/comics/{id}/permanent` returns 204 for any valid or unknown UUID.
+- After the call, Postgres has no `Comic`/`ComicChapter`/`Page`/`ScrapeJob`/`ReadingProgress` rows for that id.
+- After the ARQ job fires, `/mnt/astral-media/comics/{id}/` no longer exists.
+- Same behavior mirrored for fanfic.
+- Redis cache entry for the id is invalidated.
+
+### iOS
+
+- Long-press on library row → context menu includes red "Delete permanently" with `trash.slash` icon.
+- Detail view toolbar overflow (`ellipsis.circle`) includes "Delete permanently."
+- Either entry point shows the alert: "Delete Permanently? This will permanently delete \"{title}\" and all local data. This cannot be undone."
+- On confirm:
+  - Story disappears from library (`@Query` re-fetch).
+  - Detail view (if open) dismisses to library.
+  - Downloaded files for that story are removed from Documents.
+  - No bookmark or reading-session rows for that storyId remain.
+  - No scrape-job rows for that storyId remain.
+  - Backend returns 204 (or the request is queued as `PendingRemoteDeletion` if offline).
+- On next app launch with connectivity, any queued `PendingRemoteDeletion` is drained and removed.
+
+## Out of scope
+
+- Soft-delete UI entry point (soft-delete remains on the backend for out-of-band callers; the iOS UI no longer exposes it).
+- Undo toast / trash bin.
+- Bulk delete.
+- The pre-existing `NavigationLink` inside `LazyVStack`/`LazyVGrid` CLAUDE.md violation in both library views.
+- Auth middleware (the app is single-user; no bearer token).
+
+## Risks
+
+- **Foreign-key ordering on backend purge** — if the DELETE order is wrong, Postgres will raise. The spec's ordering (pages → chapters → scrape jobs → reading progress → parent row) should be verified against actual FK constraints in the models; if `ON DELETE CASCADE` is already configured, some deletes may be unnecessary.
+- **ARQ enqueue failure after the DB commit** — the row is gone from the DB but the media wipe never fires. Matches the existing pattern in `archive_comic` / `unarchive_comic` (logged as warning, not fatal). `cleanup_task` could be extended to orphan-scan media directories weekly, but that's out of scope.
+- **Retry queue unbounded growth** — if the user frequently deletes offline, `PendingRemoteDeletion` accumulates. Mitigated by idempotent backend (duplicates are 204s) and launch-time drain. Cap at some sane max if testing reveals unbounded growth.
+- **Author rows going stale** — `LocalAuthor` rows that were only referenced by the deleted story become orphans. Existing `OrphanCleanupService` already handles this pattern; verify it covers the author-only-reference case.
+- **Spec references models that may not exist** — `LocalScrapeJob`, `LocalReadingSession`, `LocalBookmark` presence + `storyId` field name must be verified during implementation. Adjust query predicates accordingly.


### PR DESCRIPTION
## Summary

First of two PRs for AST-19. **Backend-only.**

- New `DELETE /api/v1/comics/{id}/permanent` and `DELETE /api/v1/fanfic/{id}/permanent` routes.
- New `permanent_delete_comic` / `permanent_delete_fanfic` services that hard-delete the row and all dependents in FK-safe order: pages → chapters → join tables (authors/tags) → polymorphic `reading_progress` → parent → `scrape_jobs` (last; FK from parent.scrape_job_id).
- New ARQ tasks `comic_media_wipe_task` (rmtrees both `comics/{id}` and `archive/comics/{id}` paths under `block_volume_path`) and `fanfic_media_wipe_task` (no-op placeholder; fanfic has no per-story media dir today).
- Existing `DELETE /{id}` soft-delete routes and the nightly `cleanup_task` cron are unchanged.

**Idempotency contract:** unknown ids return `204 No Content`, not `404`. The iOS retry queue (PR 2) depends on this.

Part of [AST-19](https://linear.app/nnetraganti/issue/AST-19/library-add-permanent-delete-long-press-on-library-item-and-action-in). iOS wiring lands in PR 2 once this deploys.

Spec: `docs/superpowers/specs/2026-04-17-ast-19-permanent-delete-design.md`
Plan: `docs/superpowers/plans/2026-04-17-ast-19-permanent-delete-backend.md`

## Test plan

- [x] Service unit tests for both content types (happy path + idempotent unknown-id + polymorphic-bystander coverage)
- [x] Route tests for both endpoints (204 + DB row removal + idempotent unknown-id)
- [x] Live integration on dev stack:
  - Inserted throwaway comic + chapter + 2 pages → `DELETE /comics/{id}/permanent` → 204 → DB rows gone → ARQ worker log: `comic_media_wipe_task done`
  - Inserted throwaway fanfic → `DELETE /fanfic/{id}/permanent` → 204 → ARQ worker log: `fanfic_media_wipe_task noop`
  - Same id called again → 204 (idempotent). Random unknown UUID → 204.

## Deploy notes

- Safe to ship independently. No client uses the new endpoints yet.
- The ARQ worker container must be restarted to pick up the new task registrations (does not auto-reload like uvicorn). Confirmed during the integration test that restarting `backend-arq_worker-1` registers both new tasks.
- After this deploys, PR 2 will be opened to wire the iOS client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)