### PR TITLE
[backend] add OCI E2.1.Micro stopgap compose + A1 provisioning scripts

### DIFF
--- a/backend/docker-compose.micro.yml
+++ b/backend/docker-compose.micro.yml
@@ -1,0 +1,115 @@
+# Lean stack for OCI E2.1.Micro (1GB RAM + 2GB swap).
+# No Playwright, minimal Postgres, single-worker ARQ.
+# Designed as a stopgap until A1 capacity opens up.
+
+services:
+  fastapi:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    expose:
+      - "8000"
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://astral:astral@postgres:5432/astral
+      - REDIS_URL=redis://redis:6379/0
+      - BLOCK_VOLUME_PATH=/mnt/astral-media
+      - STATIC_BASE_URL=http://${PUBLIC_IP:-localhost}:8000/static
+      - ARQ_MAX_JOBS=2
+      - SOFT_DELETE_DAYS=5
+      - COOKIE_CACHE_TTL_SECS=86400
+      - LOG_LEVEL=INFO
+    volumes:
+      - astral_media:/mnt/astral-media
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - astral_net
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: astral
+      POSTGRES_PASSWORD: astral
+      POSTGRES_DB: astral
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    # Tune for low memory: 32MB shared_buffers, 64MB work_mem budget
+    command: >
+      postgres
+        -c shared_buffers=32MB
+        -c work_mem=4MB
+        -c effective_cache_size=128MB
+        -c max_connections=20
+        -c wal_buffers=1MB
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U astral"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 192M
+    networks:
+      - astral_net
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --maxmemory 48mb --maxmemory-policy allkeys-lru
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+    networks:
+      - astral_net
+
+  arq_worker:
+    build:
+      context: .
+      dockerfile: Dockerfile  # Same as API — no Playwright on Micro
+    environment:
+      - DATABASE_URL=postgresql+asyncpg://astral:astral@postgres:5432/astral
+      - REDIS_URL=redis://redis:6379/0
+      - BLOCK_VOLUME_PATH=/mnt/astral-media
+      - STATIC_BASE_URL=http://${PUBLIC_IP:-localhost}:8000/static
+      - ARQ_MAX_JOBS=2
+      - SOFT_DELETE_DAYS=5
+      - COOKIE_CACHE_TTL_SECS=86400
+      - LOG_LEVEL=INFO
+      - SCRAPE_CHAPTER_CONCURRENCY=2
+      - SCRAPE_PAGE_CONCURRENCY=4
+    volumes:
+      - astral_media:/mnt/astral-media
+    command: ["arq", "app.worker.WorkerSettings"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    networks:
+      - astral_net
+
+volumes:
+  postgres_data:
+  astral_media:
+
+networks:
+  astral_net:
+    driver: bridge

--- a/backend/scripts/provision_oci.sh
+++ b/backend/scripts/provision_oci.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Retry OCI A1 instance creation until capacity is available
+# Usage: bash scripts/provision_oci.sh
+
+set -uo pipefail
+
+TENANCY="ocid1.tenancy.oc1..aaaaaaaatjkppg2i7z3ad4itqk3u2lbvwqoglq254lcmjkd2zbmutvcw44lq"
+AD="dgpj:US-SANJOSE-1-AD-1"
+SUBNET="ocid1.subnet.oc1.us-sanjose-1.aaaaaaaayur5w25otaxtmsowu7k3fq7ki735maikdndcwxpjvv7nneee436q"
+IMAGE="ocid1.image.oc1.us-sanjose-1.aaaaaaaa5apepyr4swomu4cuoqbfja4s5iyn4xbdwqfm5odivwjoreve26xq"
+SSH_KEY="$(cat ~/.ssh/astral_oci.pub)"
+SHAPE="VM.Standard.A1.Flex"
+OCPUS=2
+MEMORY=12
+BOOT_VOLUME_GB=50
+INSTANCE_NAME="astral-backend"
+RETRY_INTERVAL=60
+
+echo "=== Astral OCI Instance Provisioner ==="
+echo "Shape:  $SHAPE ($OCPUS OCPU / ${MEMORY}GB RAM)"
+echo "Image:  Canonical Ubuntu 22.04 aarch64"
+echo "AD:     $AD"
+echo "Subnet: public subnet-astral-vcn"
+echo ""
+echo "Retrying every ${RETRY_INTERVAL}s until capacity is available..."
+echo "Press Ctrl+C to stop."
+echo ""
+
+ATTEMPT=0
+while true; do
+  ATTEMPT=$((ATTEMPT + 1))
+  echo "[$(date '+%H:%M:%S')] Attempt $ATTEMPT..."
+
+  RESULT=$(oci compute instance launch \
+    --compartment-id "$TENANCY" \
+    --availability-domain "$AD" \
+    --subnet-id "$SUBNET" \
+    --image-id "$IMAGE" \
+    --shape "$SHAPE" \
+    --shape-config "{\"ocpus\": $OCPUS, \"memoryInGBs\": $MEMORY}" \
+    --display-name "$INSTANCE_NAME" \
+    --ssh-authorized-keys-file <(echo "$SSH_KEY") \
+    --boot-volume-size-in-gbs "$BOOT_VOLUME_GB" \
+    --assign-public-ip true \
+    --wait-for-state RUNNING \
+    --max-wait-seconds 300 \
+    2>&1) && STATUS=0 || STATUS=$?
+
+  if [ $STATUS -eq 0 ]; then
+    echo ""
+    echo "=== SUCCESS ==="
+    PUBLIC_IP=$(echo "$RESULT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['data']['public-ip'] if 'data' in d else '')" 2>/dev/null || \
+      oci compute instance list \
+        --compartment-id "$TENANCY" \
+        --display-name "$INSTANCE_NAME" \
+        --lifecycle-state RUNNING \
+        --query "data[0].id" --raw-output | xargs -I{} oci compute instance list-vnics --instance-id {} --query "data[0].\"public-ip\"" --raw-output)
+    echo "Instance created!"
+    echo "Public IP: $PUBLIC_IP"
+    echo ""
+    echo "SSH:  ssh -i ~/.ssh/astral_oci ubuntu@$PUBLIC_IP"
+    break
+  fi
+
+  if echo "$RESULT" | grep -qE "Out of host capacity|Out of capacity|InternalError"; then
+    echo "  Out of capacity — retrying in ${RETRY_INTERVAL}s..."
+  else
+    echo "  Unexpected error:"
+    echo "$RESULT" | tail -5
+    echo "  Retrying in ${RETRY_INTERVAL}s..."
+  fi
+
+  sleep "$RETRY_INTERVAL"
+done

--- a/backend/scripts/retry-a1-launch.sh
+++ b/backend/scripts/retry-a1-launch.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Retry OCI A1 instance launch until capacity is available.
+# Run via cron: */30 * * * * /path/to/retry-a1-launch.sh >> /tmp/oci-a1-retry.log 2>&1
+#
+# Once the A1 launches, this script creates a marker file and stops retrying.
+# You'll get the instance details in the log and can migrate from the Micro.
+
+set -euo pipefail
+
+TENANCY="ocid1.tenancy.oc1..aaaaaaaatjkppg2i7z3ad4itqk3u2lbvwqoglq254lcmjkd2zbmutvcw44lq"
+AD="dgpj:US-SANJOSE-1-AD-1"
+SUBNET="ocid1.subnet.oc1.us-sanjose-1.aaaaaaaayur5w25otaxtmsowu7k3fq7ki735maikdndcwxpjvv7nneee436q"
+IMAGE="ocid1.image.oc1.us-sanjose-1.aaaaaaaa3bhtihetcgdkvl2srbvm23l5guf5wlmtq3toyht2l6kcuxqa2adq"
+SSH_KEY_FILE="$HOME/.ssh/astral_oci.pub"
+MARKER="/tmp/oci-a1-launched.marker"
+
+# Don't retry if already launched
+if [ -f "$MARKER" ]; then
+    echo "$(date): A1 already launched (marker exists). Skipping."
+    exit 0
+fi
+
+echo "$(date): Attempting A1 launch (4 OCPU, 24GB)..."
+
+RESULT=$(oci compute instance launch \
+  -c "$TENANCY" \
+  --availability-domain "$AD" \
+  --shape "VM.Standard.A1.Flex" \
+  --shape-config '{"ocpus": 4, "memoryInGBs": 24}' \
+  --image-id "$IMAGE" \
+  --subnet-id "$SUBNET" \
+  --assign-public-ip true \
+  --display-name "astral-server" \
+  --ssh-authorized-keys-file "$SSH_KEY_FILE" \
+  --output json 2>&1) || true
+
+if echo "$RESULT" | grep -q '"lifecycle-state"'; then
+    INSTANCE_ID=$(echo "$RESULT" | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['id'])")
+    echo "$(date): SUCCESS! A1 instance launched."
+    echo "Instance ID: $INSTANCE_ID"
+    echo "$RESULT" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)['data']
+print(f\"Display Name: {d['display-name']}\")
+print(f\"State: {d['lifecycle-state']}\")
+print(f\"Shape: {d['shape']}\")
+"
+    echo "$INSTANCE_ID" > "$MARKER"
+    echo "$(date): Marker written to $MARKER. Disable the cron job and set up the A1."
+
+    # macOS notification
+    osascript -e 'display notification "A1 instance launched! Check /tmp/oci-a1-retry.log" with title "OCI A1 Ready"' 2>/dev/null || true
+else
+    echo "$(date): Failed — $(echo "$RESULT" | grep -o '"message": "[^"]*"' | head -1)"
+fi


### PR DESCRIPTION
## Summary
- `backend/docker-compose.micro.yml` — lean 256 MB compose for the OCI E2.1.Micro free-tier (1 GB RAM). No Playwright, `ARQ_MAX_JOBS=2`, trimmed Postgres tunings. Stopgap until A1 capacity opens.
- `backend/scripts/provision_oci.sh` — initial A1 provisioning.
- `backend/scripts/retry-a1-launch.sh` — cron-friendly retry loop for A1 capacity.

These were sitting untracked on a feature branch; moving them to `development` so the OCI ops flow is checked in.

## Test plan
- [ ] `docker compose -f backend/docker-compose.micro.yml config` validates
- [ ] scripts have executable bit (chmod +x) preserved through git

🤖 Generated with [Claude Code](https://claude.com/claude-code)