### PR TITLE
[chore] AST-36 add CHANGELOG.md and document recent shipped work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+A running log of what shipped to `development`. Most recent first.
+
+Add a new entry whenever you merge a feature/fix PR into `development`. Keep entries terse — the PR body has the detail; this is the index.
+
+## 2026-04-19
+
+### iOS
+
+- **AST-34** — Fanfic reader chapter-header compaction: title font multiplier `1.4×` → `1.2×`, removed in-flow reading-time HStack (and dead `readingTimeLabel` helper), tightened header VStack spacing `6→4`, header bottom padding `8→4`, outer ScrollView vertical padding `20→10`. First paragraph sits visibly higher; design language preserved. ([PR #34](https://github.com/agenticCoder97/IosTestApp/pull/34))
+- **AST-27** — `MorphLandingView` cleanup: extracted phase-geometry magic numbers from `runPhase1`/`runPhase2` into a file-private `PhaseGeometry` enum (4 Phase 1 fractions + 2 Phase 2 fractions), added doc comments on the Phase 3 spring driver and `.onDisappear` animation-token rotation. Sub-item #1 (move `blueColor` to DesignSystem) was already done by AST-21. ([PR #34](https://github.com/agenticCoder97/IosTestApp/pull/34))
+- **AST-21** — App logo + AstralColors tokens: added `AstralColors.blue` / `goldLight` / `goldDark` tokens, new `AstralLogo` SwiftUI component in DesignSystem, swapped inline blue hex in `RootView` for the token. ([PR #27](https://github.com/agenticCoder97/IosTestApp/pull/27))
+
+### Backend + iOS
+
+- **AST-30** — MangaDex as a first-class comic source: new `MangadexScraper(BaseScraper)` (search / metadata / chapter list / `/at-home/server/` page URLs / `download_image` override that POSTs MD@Home reports per ToS), shared `MangadexHTTPClient` with `aiolimiter` (5/s global + 40/min for at-home) + 5×429-in-60s circuit breaker, synchronous title matcher hook on `POST /scrape/comic` (returns `202 { match }` envelope on ≥0.85 confidence), iOS `MangaDexMatchDialog` confirm sheet, three `previous_source*` audit columns on `Comic`. Out of scope split: OAuth porn-tier ([AST-35](https://linear.app/nnetraganti/issue/AST-35)); attribution UI deferred (single-user). ([PR #33](https://github.com/agenticCoder97/IosTestApp/pull/33))
+
+## 2026-04-18 and earlier
+
+See `git log` and `docs/superpowers/specs/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,10 @@ main                    ← production releases (god branch, protected)
   - `Resolves AST-123`
 - Multiple issues: one magic-word line per issue (`Fixes AST-123`, `Fixes AST-124`).
 
+### Release log
+
+- Add a brief entry to [CHANGELOG.md](CHANGELOG.md) at the repo root whenever you merge a feature/fix PR into `development`. Most recent first; the PR body has the detail, the changelog is the index.
+
 ### Device targeting (no separate branches needed)
 - **Simulator**: `#if targetEnvironment(simulator)` → `localhost:8000`
 - **Physical device (debug)**: `#else` in DEBUG → Mac's WiFi IP (`192.168.0.108:8000`)


### PR DESCRIPTION
Closes AST-36
Closes AST-37
Closes AST-38

## Summary

- Adds `CHANGELOG.md` at repo root with entries for the four recently shipped tickets (AST-21, AST-27, AST-30, AST-34).
- Adds a "Release log" subsection in `CLAUDE.md` pointing future Claude sessions to update `CHANGELOG.md` when shipping work.

## Why

Doubles as an end-to-end test of the Linear ↔ GitHub integration. If the magic words above (`Closes AST-36`, `Closes AST-37`, `Closes AST-38`) auto-close all three Linear issues on merge, the integration is correctly configured for the Astral team and the `agenticCoder97/IosTestApp` repo.

## Test plan

- [ ] On open: this PR appears as an attachment on AST-36, AST-37, AST-38 in Linear (within ~30s).
- [ ] On merge: all three issues auto-transition from Backlog → Done with `completedAt` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)