### PR TITLE
[backend][ios] AST-18 guard against "Unknown Title" scrapes polluting library

### DIFF
--- a/backend/app/scrapers/fanfic/_fanficfare_runner.py
+++ b/backend/app/scrapers/fanfic/_fanficfare_runner.py
@@ -112,6 +112,8 @@ def _fetch_sync(url: str, cookies: list[dict], user_agent: str
     adapter = _get_adapter(url, cookies, user_agent)
     adapter.getStoryMetadataOnly()
     meta = _to_story_metadata(adapter, url)
+    if not meta.title or meta.title.lower() in ("unknown title", "unknown"):
+        raise FanFicFareError(f"FanFicFare returned invalid title for {url}: {meta.title!r}")
 
     chapter_texts: list[ChapterText] = []
     for i, record in enumerate(adapter.story.getChapters(), start=1):

--- a/backend/app/scrapers/fanfic/ffnet.py
+++ b/backend/app/scrapers/fanfic/ffnet.py
@@ -58,6 +58,8 @@ class FanfictionNetScraper(BaseScraper):
 
         try:
             fh_meta = await _fichub.fetch_story_meta(url)
+            if not fh_meta.title or fh_meta.title.lower() in ("unknown title", "unknown"):
+                raise _fichub.FicHubError(f"FicHub returned invalid title for {url}: {fh_meta.title!r}")
             chapters = await _fichub.download_and_split_epub(fh_meta.epub_url)
             meta = StoryMetadata(
                 title=fh_meta.title,

--- a/backend/app/tasks/fanfic_scrape_task.py
+++ b/backend/app/tasks/fanfic_scrape_task.py
@@ -107,7 +107,8 @@ async def fanfic_scrape_task(ctx, job_id: str):
             result = await db.execute(select(Fanfic).where(Fanfic.id == job.story_id))
             fanfic = result.scalar_one_or_none()
             if fanfic:
-                fanfic.title = metadata.title
+                if metadata.title and metadata.title.lower() not in ("unknown title", "unknown"):
+                    fanfic.title = metadata.title
                 if metadata.description is not None:
                     fanfic.summary = metadata.description
                 if metadata.language is not None:

--- a/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Library/FanficLibraryView.swift
+++ b/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Library/FanficLibraryView.swift
@@ -31,7 +31,7 @@ struct FanficLibraryView: View {
     }
 
     private var filteredFanfics: [LocalFanfic] {
-        var result = allFanfics.filter { $0.totalChapters > 0 && $0.title != "Pending scrape..." }
+        var result = allFanfics.filter { $0.totalChapters > 0 && $0.title != "Pending scrape..." && $0.title != "Unknown Title" }
         if filterFavourites {
             result = result.filter { $0.isFavorite }
         }

--- a/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Scrapes/FanficScrapesView.swift
+++ b/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/Scrapes/FanficScrapesView.swift
@@ -166,7 +166,7 @@ struct FanficScrapesView: View {
         }
         for job in missingStoryJobs {
             guard let dto: FanficResponse = try? await APIClient.shared.request(.fanficDetail(id: job.storyId)) else { continue }
-            guard dto.title != "Pending scrape..." else { continue }
+            guard dto.title != "Pending scrape..." && dto.title != "Unknown Title" else { continue }
             let fanfic = LocalFanfic(
                 id: dto.id,
                 title: dto.title,


### PR DESCRIPTION
## Summary

Fixes [AST-18](https://linear.app/nnetraganti/issue/AST-18). When FicHub or FanFicFare returned `title="Unknown Title"` with `total_chapters=1`, the scrape task blindly wrote that to the `fanfics` row, and the iOS library filter (`totalChapters > 0 && title != "Pending scrape..."`) let it through as a broken card.

**Backend:**
- `fanfic_scrape_task` only persists `metadata.title` if it is non-empty and not `"Unknown Title"` / `"unknown"` (case-insensitive).
- `ffnet._resolve` rejects FicHub results with sentinel titles so the fallback chain fails cleanly rather than silently writing garbage.
- `_fanficfare_runner._fetch_sync` applies the same guard on the FFF primary path.

**iOS (belt-and-suspenders):**
- `FanficLibraryView` filter skips `LocalFanfic` with title `"Unknown Title"` in addition to `"Pending scrape..."`.
- `FanficScrapesView.syncActiveJobs` stub-skip extended likewise.

Closes AST-18

## Test plan

- [x] Re-scrape an FFNet fanfic that previously landed as "Unknown Title" — title now populated correctly after re-scrape.
- [x] Library no longer shows broken "Unknown Title" cards for stale pre-fix rows.
- [x] Existing scraper + library tests still pass (no assertions on the removed behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)