### PR TITLE
[backend] AST-50 fix certbot image reference

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -75,7 +75,9 @@ services:
       - astral_net
 
   certbot:
-    image: certbot/dns-duckdns:latest
+    # community-maintained image bundling certbot + certbot-dns-duckdns plugin;
+    # the previously-referenced certbot/dns-duckdns doesn't exist on Docker Hub.
+    image: infinityofspace/certbot_dns_duckdns:latest
     env_file:
       - .env.oci
     volumes:


### PR DESCRIPTION
## Summary

- `certbot/dns-duckdns` doesn't exist on Docker Hub — pull fails with `repository does not exist or may require 'docker login'`
- Switch to `infinityofspace/certbot_dns_duckdns:latest` (community, widely used, bundles certbot + certbot-dns-duckdns plugin)
- Verified on the A1: image pulls cleanly, `certbot plugins` lists `dns-duckdns` correctly

## Discovered during AST-50

Tried to issue the initial LE cert via `docker compose run certbot ...` and got the pull failure. Root-caused to a non-existent image reference in the original compose.

## Test plan

- [x] `docker manifest inspect infinityofspace/certbot_dns_duckdns:latest` returns valid manifest
- [x] `docker run --rm infinityofspace/certbot_dns_duckdns:latest plugins` shows `dns-duckdns` plugin registered
- [ ] Post-merge: re-run the certbot one-shot to issue the LE cert

Closes AST-50 (fix part; cert issuance itself is the follow-up in the same Linear issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)