### PR TITLE
[backend] AST-49 fix nginx worker_processes placement

### DIFF
--- a/backend/nginx/nginx.conf
+++ b/backend/nginx/nginx.conf
@@ -1,5 +1,7 @@
+worker_processes auto;
+
 events {
-    worker_processes auto;
+    worker_connections 1024;
 }
 
 http {


### PR DESCRIPTION
## Summary

- `worker_processes auto;` was incorrectly nested inside the `events{}` block in `backend/nginx/nginx.conf`
- nginx rejects this at startup with `"worker_processes" directive is not allowed here` (main context only)
- Moved to top-level main context; added the missing `worker_connections 1024;` to the events block

## Discovered while

Bringing up the prod stack on A1 (AST-49). nginx was crash-looping on the invalid config; all other services healthy. This fix unblocks the deploy.

## Test plan

- [x] `nginx -t` passes on the fixed config
- [ ] Post-merge: `git pull` on A1 → `docker compose restart nginx` → no more restart loop
- [ ] End-to-end `curl https://astral-reader.duckdns.org/api/v1/health` returns 200

Closes AST-49 (partial — nginx fix; rest of deploy verification continues in the same Linear issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)