### PR TITLE
[backend] AST-51 weekly pg_dump backup cron to Object Storage

### DIFF
--- a/backend/scripts/astral-backup-setup.md
+++ b/backend/scripts/astral-backup-setup.md
@@ -1,0 +1,192 @@
+# Astral Postgres backup — setup runbook (AST-51)
+
+Weekly `pg_dump` of the production Postgres to OCI Object Storage, retained
+for 56 days (8 weekly backups) via a bucket lifecycle rule. Auth uses an
+OCI **instance principal** — no API keys land on the A1 host.
+
+Script: [`astral-backup.sh`](./astral-backup.sh)
+Bucket: `astral-backups` (root compartment, standard tier, private)
+Schedule: Sundays 04:00 UTC (`0 4 * * 0`)
+
+---
+
+## OCI resources (already provisioned)
+
+The items below were created once via the OCI CLI and do **not** need to be
+re-run. They are recorded here so an operator can re-create them from scratch
+if the tenancy is ever lost.
+
+| Resource | OCID / ID |
+| --- | --- |
+| Bucket `astral-backups` | `ocid1.bucket.oc1.us-sanjose-1.aaaaaaaafcgk5plwd7suxlg6ja3pzce4yafm63l7runysxn5ghhsdzz3tl7a` |
+| Lifecycle rule | `delete-after-56d` (inclusion pattern `astral-*.dump.gz`) |
+| Dynamic group `astral-a1-backup` | `ocid1.dynamicgroup.oc1..aaaaaaaa357nlifpaev3zlzztzjk4rxojsic22jjlsi23jnyapwvb6juiyga` |
+| Policy `astral-backup-policy` | `ocid1.policy.oc1..aaaaaaaakv2ijrb4sikxhf4k2bpetyermfqwlioxlm54ekbv45vphmnsu4la` |
+| Object Storage namespace | `axfta6t5vu1x` |
+| Tenancy | `ocid1.tenancy.oc1..aaaaaaaatjkppg2i7z3ad4itqk3u2lbvwqoglq254lcmjkd2zbmutvcw44lq` |
+| A1 instance (`astral-server`) | `ocid1.instance.oc1.us-sanjose-1.anzwuljr47solkicfjexpqt7oe76wwrsxv4iljnwdfejinr5u2iqhoxqqlwq` |
+
+### Re-create from scratch (reference)
+
+```bash
+TENANCY=ocid1.tenancy.oc1..aaaaaaaatjkppg2i7z3ad4itqk3u2lbvwqoglq254lcmjkd2zbmutvcw44lq
+NS=$(oci os ns get --query data --raw-output)   # axfta6t5vu1x
+INSTANCE_OCID=ocid1.instance.oc1.us-sanjose-1.anzwuljr47solkicfjexpqt7oe76wwrsxv4iljnwdfejinr5u2iqhoxqqlwq
+
+# 1. Bucket (private, standard tier)
+oci os bucket create \
+  --compartment-id "$TENANCY" \
+  --name astral-backups \
+  --namespace-name "$NS" \
+  --storage-tier Standard \
+  --public-access-type NoPublicAccess
+
+# 2. Dynamic group (matches exactly one instance — our A1)
+oci iam dynamic-group create \
+  --compartment-id "$TENANCY" \
+  --name astral-a1-backup \
+  --description "astral-server A1 instance identity for pg_dump backup uploads" \
+  --matching-rule "instance.id = '$INSTANCE_OCID'"
+
+# 3. Policy — two statements:
+#    (a) A1 can manage objects in the bucket via its instance principal
+#    (b) Object Storage service can run the lifecycle rule on the bucket
+cat > /tmp/stmts.json <<EOF
+[
+  "allow dynamic-group astral-a1-backup to manage object-family in tenancy where target.bucket.name='astral-backups'",
+  "allow service objectstorage-us-sanjose-1 to manage object-family in tenancy where target.bucket.name='astral-backups'"
+]
+EOF
+oci iam policy create \
+  --compartment-id "$TENANCY" \
+  --name astral-backup-policy \
+  --description "Permissions for A1 backup uploads + Object Storage lifecycle on astral-backups" \
+  --statements file:///tmp/stmts.json
+
+# 4. Lifecycle rule — delete astral-*.dump.gz objects older than 56 days
+cat > /tmp/lifecycle.json <<EOF
+[
+  {
+    "name": "delete-after-56d",
+    "action": "DELETE",
+    "timeAmount": 56,
+    "timeUnit": "DAYS",
+    "isEnabled": true,
+    "objectNameFilter": { "inclusionPatterns": ["astral-*.dump.gz"] }
+  }
+]
+EOF
+oci os object-lifecycle-policy put \
+  --bucket-name astral-backups \
+  --namespace-name "$NS" \
+  --items file:///tmp/lifecycle.json \
+  --force
+```
+
+> Cost: all four resources are free. Bucket storage is under the Always Free
+> 20 GB Standard tier limit; a compressed `astral` dump is expected to be
+> well under 100 MB.
+
+---
+
+## A1 host install (one-time, post-merge)
+
+SSH into `astral-server`:
+
+```bash
+ssh -i ~/.ssh/astral_oci ubuntu@163.192.4.88
+```
+
+Then as `ubuntu`:
+
+```bash
+# 1. Install OCI CLI via pip (user-level; no ~/.oci/config — we use instance principal).
+sudo apt-get update && sudo apt-get install -y python3-pip
+pip install --user oci-cli
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+export PATH="$HOME/.local/bin:$PATH"
+
+# 2. Verify instance-principal auth works.
+oci --auth instance_principal os ns get
+# Expect: {"data": "axfta6t5vu1x"}
+
+# 3. Deploy the script (it's checked in at backend/scripts/astral-backup.sh).
+cd ~/astral   # or wherever the repo clone lives
+git pull origin development
+sudo install -m 0755 -o root -g root \
+  backend/scripts/astral-backup.sh /usr/local/bin/astral-backup.sh
+
+# 4. Prep the log file.
+sudo touch /var/log/astral-backup.log
+sudo chmod 0644 /var/log/astral-backup.log
+
+# 5. Smoke-test dry-run, then a real run.
+sudo /usr/local/bin/astral-backup.sh --dry-run
+sudo /usr/local/bin/astral-backup.sh
+
+# 6. Verify the object landed in the bucket.
+oci --auth instance_principal os object list \
+  --bucket-name astral-backups \
+  --namespace-name axfta6t5vu1x \
+  --query 'data[*].{name:name,size:size}'
+
+# 7. Install the cron entry (Sundays 04:00 UTC). cron.d needs root ownership.
+echo '0 4 * * 0 root /usr/local/bin/astral-backup.sh >> /var/log/astral-backup.log 2>&1' \
+  | sudo tee /etc/cron.d/astral-backup
+sudo chmod 0644 /etc/cron.d/astral-backup
+```
+
+> The cron entry uses `/etc/cron.d/` (system cron) rather than a user
+> crontab so the job runs as `root` and has permission to `docker compose
+> exec` without extra groups. `sudo` is required for docker compose on the
+> current host setup.
+
+If the compose directory is not `/home/ubuntu/astral/backend`, override it:
+
+```bash
+echo '0 4 * * 0 root ASTRAL_COMPOSE_DIR=/path/to/backend /usr/local/bin/astral-backup.sh >> /var/log/astral-backup.log 2>&1' \
+  | sudo tee /etc/cron.d/astral-backup
+```
+
+---
+
+## Restore
+
+```bash
+# On any host with oci CLI + the astral docker compose stack running.
+BUCKET=astral-backups
+NS=axfta6t5vu1x
+OBJECT=astral-20260420-040000.dump.gz   # pick from `oci os object list`
+
+oci --auth instance_principal os object get \
+  --bucket-name "$BUCKET" --namespace-name "$NS" \
+  --name "$OBJECT" --file - \
+  | gunzip \
+  | docker compose -f /home/ubuntu/astral/backend/docker-compose.yml \
+      exec -T postgres pg_restore -U astral -d astral --clean --if-exists
+```
+
+For a fully clean restore (drop + recreate the database first):
+
+```bash
+docker compose exec -T postgres psql -U astral -d postgres \
+  -c "DROP DATABASE astral;" \
+  -c "CREATE DATABASE astral OWNER astral;"
+```
+
+then pipe the `pg_restore` as above without `--clean --if-exists`.
+
+---
+
+## Operational notes
+
+- **Log location**: `/var/log/astral-backup.log` (appended every run).
+- **Failure signal**: cron emails root on non-zero exit. Pipe-failure safety
+  is provided by `set -euo pipefail` inside the script.
+- **Kill switch**: remove `/etc/cron.d/astral-backup` to pause weekly runs.
+- **Retention**: objects are auto-deleted after 56 days by the bucket
+  lifecycle rule. To change retention, update `timeAmount` in the lifecycle
+  policy JSON and re-`put`.
+- **Cost**: Object Storage is in the Always Free envelope (20 GB standard).
+  A dozen compressed dumps at ~50 MB each is <1 GB, orders of magnitude
+  under the cap. No budget alarm change needed.

--- a/backend/scripts/astral-backup.sh
+++ b/backend/scripts/astral-backup.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# astral-backup.sh — weekly pg_dump backup of the Astral Postgres database to
+# OCI Object Storage (bucket: astral-backups).
+#
+# Runs on the OCI A1 host (astral-server), NOT inside a container. The script
+# pipes pg_dump from the running `postgres` compose service through gzip into
+# `oci os object put` with instance-principal auth. Object Storage lifecycle
+# policy deletes objects older than 56 days (8 weekly backups).
+#
+# ---------------------------------------------------------------------------
+# INSTALL (one-time, on the A1 host)
+# ---------------------------------------------------------------------------
+#   # 1. Install OCI CLI (Python user install is enough; no ~/.oci/config
+#   #    needed because we use instance principal).
+#   pip install --user oci-cli
+#   export PATH="$HOME/.local/bin:$PATH"   # persist in ~/.bashrc
+#
+#   # 2. Copy this script into place and make it executable.
+#   sudo install -m 0755 -o root -g root \
+#     astral-backup.sh /usr/local/bin/astral-backup.sh
+#
+#   # 3. Ensure log file exists and is writable by whoever runs cron (root).
+#   sudo touch /var/log/astral-backup.log
+#   sudo chmod 0644 /var/log/astral-backup.log
+#
+#   # 4. Install the crontab entry (Sundays 04:00 UTC).
+#   echo '0 4 * * 0 /usr/local/bin/astral-backup.sh >> /var/log/astral-backup.log 2>&1' \
+#     | sudo tee /etc/cron.d/astral-backup
+#
+#   # 5. Smoke-test before waiting for cron.
+#   sudo /usr/local/bin/astral-backup.sh --dry-run
+#   sudo /usr/local/bin/astral-backup.sh
+#
+# ---------------------------------------------------------------------------
+# RESTORE
+# ---------------------------------------------------------------------------
+# Pick an object name from the bucket:
+#   oci --auth instance_principal os object list \
+#     --bucket-name astral-backups --namespace-name "$(oci os ns get --query data --raw-output)"
+#
+# Download and restore into the running `postgres` container:
+#   oci --auth instance_principal os object get \
+#     --bucket-name astral-backups \
+#     --namespace-name "$(oci os ns get --query data --raw-output)" \
+#     --name astral-YYYYMMDD-HHMMSS.dump.gz --file - \
+#     | gunzip \
+#     | docker compose -f /home/ubuntu/astral/backend/docker-compose.yml \
+#         exec -T postgres pg_restore -U astral -d astral --clean --if-exists
+#
+# (Drop/recreate the DB first if you want a clean slate:
+#   docker compose exec -T postgres psql -U astral -d postgres \
+#     -c "DROP DATABASE astral;" -c "CREATE DATABASE astral OWNER astral;")
+#
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+# --- config -----------------------------------------------------------------
+BUCKET="astral-backups"
+COMPOSE_DIR="${ASTRAL_COMPOSE_DIR:-/home/ubuntu/astral/backend}"
+COMPOSE_FILE="${ASTRAL_COMPOSE_FILE:-docker-compose.yml}"
+PG_SERVICE="${ASTRAL_PG_SERVICE:-postgres}"
+PG_USER="${ASTRAL_PG_USER:-astral}"
+PG_DB="${ASTRAL_PG_DB:-astral}"
+LOG_FILE="${ASTRAL_BACKUP_LOG:-/var/log/astral-backup.log}"
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    -h|--help)
+      sed -n '2,48p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown flag: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# --- logging ----------------------------------------------------------------
+# Mirror stdout/stderr to the log file. Cron also redirects to the same file;
+# the dupe is intentional so an interactive invocation still leaves a trail.
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+TS_START_EPOCH=$(date -u +%s)
+TS_START_ISO=$(date -u -d "@$TS_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+  || date -u -r "$TS_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)
+OBJECT_NAME="astral-$(date -u -d "@$TS_START_EPOCH" +%Y%m%d-%H%M%S 2>/dev/null \
+  || date -u -r "$TS_START_EPOCH" +%Y%m%d-%H%M%S).dump.gz"
+
+echo "=============================================================="
+echo "[astral-backup] start  $TS_START_ISO  object=$OBJECT_NAME  dry_run=$DRY_RUN"
+echo "=============================================================="
+
+# --- auto-detect namespace --------------------------------------------------
+# Use instance principal everywhere so we never need ~/.oci/config on the host.
+# In dry-run we skip the call so the script can be smoke-tested off-host (e.g.
+# on a laptop) without instance-metadata-service access.
+if $DRY_RUN; then
+  NAMESPACE="<auto-detect-via-instance-principal>"
+else
+  NAMESPACE=$(oci --auth instance_principal os ns get --query data --raw-output)
+  if [[ -z "$NAMESPACE" ]]; then
+    echo "[astral-backup] ERROR: failed to resolve Object Storage namespace" >&2
+    exit 1
+  fi
+fi
+echo "[astral-backup] namespace=$NAMESPACE bucket=$BUCKET"
+
+# --- pipeline ---------------------------------------------------------------
+cd "$COMPOSE_DIR"
+
+if $DRY_RUN; then
+  echo "[astral-backup] DRY RUN — skipping pg_dump + upload"
+  echo "[astral-backup] would run:"
+  echo "  docker compose -f $COMPOSE_FILE exec -T $PG_SERVICE \\"
+  echo "    pg_dump -U $PG_USER --format=custom $PG_DB \\"
+  echo "    | gzip -9 \\"
+  echo "    | oci --auth instance_principal os object put \\"
+  echo "        --bucket-name $BUCKET --namespace-name $NAMESPACE \\"
+  echo "        --name $OBJECT_NAME --file - --force"
+  TS_END_EPOCH=$(date -u +%s)
+  echo "[astral-backup] end    duration=$((TS_END_EPOCH - TS_START_EPOCH))s status=dry-run"
+  exit 0
+fi
+
+# `set -o pipefail` (enabled via `set -euo pipefail`) ensures a failure in any
+# stage (pg_dump, gzip, oci) fails the whole pipeline.
+docker compose -f "$COMPOSE_FILE" exec -T "$PG_SERVICE" \
+  pg_dump -U "$PG_USER" --format=custom "$PG_DB" \
+  | gzip -9 \
+  | oci --auth instance_principal os object put \
+      --bucket-name "$BUCKET" \
+      --namespace-name "$NAMESPACE" \
+      --name "$OBJECT_NAME" \
+      --file - \
+      --force
+
+# --- verify + report --------------------------------------------------------
+HEAD_JSON=$(oci --auth instance_principal os object head \
+  --bucket-name "$BUCKET" \
+  --namespace-name "$NAMESPACE" \
+  --name "$OBJECT_NAME")
+SIZE=$(echo "$HEAD_JSON" | grep -o '"content-length": *"[0-9]*"' | grep -o '[0-9]\+' || echo "?")
+
+TS_END_EPOCH=$(date -u +%s)
+DURATION=$((TS_END_EPOCH - TS_START_EPOCH))
+echo "[astral-backup] uploaded $OBJECT_NAME size=${SIZE}B duration=${DURATION}s"
+echo "[astral-backup] end    status=ok"


### PR DESCRIPTION
## Summary

Adds `backend/scripts/astral-backup.sh` + `backend/scripts/astral-backup-setup.md` so we can run a host-level weekly `pg_dump` on the A1 (`astral-server`) that uploads a compressed custom-format dump to the new private **`astral-backups`** OCI Object Storage bucket. Without this, a VM failure would lose every library row we have (comics, fanfics, chapters, reading progress). Since we self-host Postgres 16 on a single A1, backups are our responsibility.

The script:
- Pipes `docker compose exec -T postgres pg_dump --format=custom astral | gzip -9 | oci os object put` in one `set -euo pipefail` pipeline so any stage failure aborts the whole run.
- Authenticates with **instance principal** (no API keys on disk) via a new IAM dynamic group pinned to the A1 instance OCID.
- Auto-detects the Object Storage namespace at runtime (no hardcoded tenancy data in the script).
- Objects are named `astral-<UTC-YYYYMMDD-HHMMSS>.dump.gz` — strictly sortable, collision-safe.
- Supports `--dry-run` (skips pg_dump and upload, prints what it would do) and `--help`.
- Logs to stdout *and* tees to `/var/log/astral-backup.log`.

## Resources provisioned (free tier)

| Resource | ID |
| --- | --- |
| Bucket `astral-backups` (Standard, private) | `ocid1.bucket.oc1.us-sanjose-1.aaaaaaaafcgk5plwd7suxlg6ja3pzce4yafm63l7runysxn5ghhsdzz3tl7a` |
| Lifecycle rule `delete-after-56d` | inclusion pattern `astral-*.dump.gz`, 56-day DELETE |
| Dynamic group `astral-a1-backup` | `ocid1.dynamicgroup.oc1..aaaaaaaa357nlifpaev3zlzztzjk4rxojsic22jjlsi23jnyapwvb6juiyga` |
| Policy `astral-backup-policy` | `ocid1.policy.oc1..aaaaaaaakv2ijrb4sikxhf4k2bpetyermfqwlioxlm54ekbv45vphmnsu4la` |

All four sit safely inside the OCI Always Free envelope (20 GB Object Storage cap; compressed dumps are well under that).

The policy has two statements:

1. `allow dynamic-group astral-a1-backup to manage object-family in tenancy where target.bucket.name='astral-backups'` — the A1 can upload/list/read via its instance principal.
2. `allow service objectstorage-us-sanjose-1 to manage object-family in tenancy where target.bucket.name='astral-backups'` — required so the bucket lifecycle rule can delete aged objects.

## Post-merge install steps (human, on the A1)

Full runbook: [`backend/scripts/astral-backup-setup.md`](./backend/scripts/astral-backup-setup.md). Short version:

1. `ssh -i ~/.ssh/astral_oci ubuntu@163.192.4.88`
2. `pip install --user oci-cli` and add `~/.local/bin` to `PATH`.
3. `git pull origin development` and `sudo install -m 0755 backend/scripts/astral-backup.sh /usr/local/bin/astral-backup.sh`.
4. `sudo /usr/local/bin/astral-backup.sh --dry-run` then `sudo /usr/local/bin/astral-backup.sh` to seed the first backup.
5. Install `/etc/cron.d/astral-backup` with `0 4 * * 0 root /usr/local/bin/astral-backup.sh >> /var/log/astral-backup.log 2>&1`.

## Test plan

- [x] `bash -n astral-backup.sh` — passes syntax check.
- [x] `astral-backup.sh --dry-run` — prints the rendered pipeline, no OCI calls, exits 0.
- [x] `astral-backup.sh --help` — prints header block, exits 0.
- [x] Unknown flag exits 2 with usage error.
- [x] All four OCI resources verified with `oci ... get` after creation.
- [ ] (post-merge, on A1) Real run uploads a `.dump.gz` visible in `oci os object list`.
- [ ] (post-merge) Cron fires on Sunday 04:00 UTC; log shows duration + byte count.
- [ ] (post-merge) Restore dry-run against a throwaway DB confirms `pg_restore` works end-to-end.

Closes AST-51