### PR TITLE
[ios] AST-56 fix library refresh false-positive "Backend unreachable"

### DIFF
--- a/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/ViewModels/ComicLibraryViewModel.swift
+++ b/ios/Astral/Packages/ComicFeature/Sources/ComicFeature/ViewModels/ComicLibraryViewModel.swift
@@ -94,9 +94,11 @@ final class ComicLibraryViewModel {
         } catch let error as APIError where error == .cookieRefreshNeeded {
             errorMessage = "Browser refresh needed"
             AstralLogger.warning("fetchComics: cookie refresh needed", context: "ComicLibraryVM")
-        } catch is URLError {
-            errorMessage = "Backend unreachable — check Docker is running"
-            AstralLogger.error("fetchComics: backend unreachable", context: "ComicLibraryVM")
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            AstralLogger.info("fetchComics cancelled mid-flight", context: "ComicLibraryVM")
+        } catch let urlError as URLError {
+            errorMessage = "Couldn't reach the server — \(urlError.localizedDescription)"
+            AstralLogger.error("fetchComics URL error: \(urlError.code.rawValue) — \(urlError.localizedDescription)", context: "ComicLibraryVM")
         } catch {
             errorMessage = "Sync failed: \(error.localizedDescription)"
             AstralLogger.error("fetchComics failed: \(error)", context: "ComicLibraryVM")

--- a/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/ViewModels/FanficLibraryViewModel.swift
+++ b/ios/Astral/Packages/FanficFeature/Sources/FanficFeature/ViewModels/FanficLibraryViewModel.swift
@@ -148,9 +148,11 @@ final class FanficLibraryViewModel {
                     AstralLogger.info("Migration: thumbnail assignment complete", context: "FanficLibraryVM")
                 }
             }
-        } catch is URLError {
-            errorMessage = "Backend unreachable — check Docker is running"
-            AstralLogger.error("fetchFanfics: backend unreachable", context: "FanficLibraryVM")
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            AstralLogger.info("fetchFanfics cancelled mid-flight", context: "FanficLibraryVM")
+        } catch let urlError as URLError {
+            errorMessage = "Couldn't reach the server — \(urlError.localizedDescription)"
+            AstralLogger.error("fetchFanfics URL error: \(urlError.code.rawValue) — \(urlError.localizedDescription)", context: "FanficLibraryVM")
         } catch {
             errorMessage = "Sync failed: \(error.localizedDescription)"
             AstralLogger.error("fetchFanfics failed: \(error)", context: "FanficLibraryVM")


### PR DESCRIPTION
## Summary

Library pull-to-refresh was showing `"Backend unreachable — check Docker is running"` on every refresh, even though the backend was healthy (prod logs: every request 200 in <10 ms).

## Root cause

Both `ComicLibraryViewModel.fetchComics` and `FanficLibraryViewModel.fetchFanfics` caught `URLError` as a blanket "backend unreachable":

```swift
} catch is URLError {
    errorMessage = "Backend unreachable — check Docker is running"
}
```

`URLError` includes `URLError.cancelled`, which `URLSession` throws when SwiftUI cancels an in-flight `.task` on pull-to-refresh (`.refreshable` starts a new fetch, cancelling the old one). That's expected behavior, not an error — but it was being surfaced as one.

## Fix

Discriminate `URLError.cancelled` (silent, expected) from real URLError cases (show the actual `localizedDescription`, not "check Docker"):

```swift
} catch let urlError as URLError where urlError.code == .cancelled {
    AstralLogger.info("fetchComics cancelled mid-flight", context: "ComicLibraryVM")
} catch let urlError as URLError {
    errorMessage = "Couldn't reach the server — \(urlError.localizedDescription)"
    AstralLogger.error("fetchComics URL error: \(urlError.code.rawValue) — \(urlError.localizedDescription)",
                       context: "ComicLibraryVM")
}
```

Applied to both VMs (ComicLibrary + FanficLibrary).

## Side benefits

- "check Docker is running" wording gone (dev-flavored, obsolete now that prod = DuckDNS)
- Real network failures now surface the underlying reason (timeout, DNS, connection lost) instead of a generic "unreachable"
- `.cancelled` logs at info-level so we still see it in diagnostics without UI noise

## Test plan

- [x] Release build on iOS Simulator: **BUILD SUCCEEDED**
- [ ] On device: pull-to-refresh library view repeatedly → no banner flashes
- [ ] On device: kill backend briefly → banner shows a real-sounding message (not "check Docker")

Closes AST-56

🤖 Generated with [Claude Code](https://claude.com/claude-code)