### PR TITLE
[backend] document AST-70..77 env vars in .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,25 @@ FFNET_NEW_SCRAPER_DISABLED=false
 #   Allow dynamic-group astral-a1-backup to read usage-budgets in tenancy
 #   Allow dynamic-group astral-a1-backup to read usage-reports in tenancy
 # (both scoped to tenancy; instance principal signer + monitor container only)
+
+# ──────────────────────────────────────────────────────────────────────
+# Monitor dashboard control plane (AST-70..77)
+# ──────────────────────────────────────────────────────────────────────
+# Required to enable any /control/* endpoint (kill switches, service
+# restart, ARQ retry, on-demand backup, SQL console). Absent → 503.
+# Generate with: openssl rand -hex 32
+MONITOR_CONTROL_TOKEN=
+
+# DSN for the read-only SQL console. The astral_readonly role is
+# created by alembic migration a3b4c5d6e7f8 with SELECT-only grants
+# and a 10s statement_timeout. Rotate the password in prod.
+# MONITOR_READONLY_DSN=postgresql://astral_readonly:astral_readonly@postgres:5432/astral
+
+# Password baked into the role at migration time. Defaults to
+# 'astral_readonly' when unset. Must match the password in
+# MONITOR_READONLY_DSN above.
+# ASTRAL_READONLY_PASSWORD=astral_readonly
+
+# Where the monitor persists its audit log, on-demand pg_dump output,
+# and deploys.jsonl. Mounted via the monitor_state named volume.
+# MONITOR_STATE_DIR=/var/lib/astral-monitor


### PR DESCRIPTION
Docs-only follow-up to [#50](https://github.com/agenticCoder97/IosTestApp/pull/50). Surfaces MONITOR_CONTROL_TOKEN, MONITOR_READONLY_DSN, ASTRAL_READONLY_PASSWORD, MONITOR_STATE_DIR in .env.example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)