### PR TITLE
[backend] fix monitor dashboard broken /monitor/* routing + controls.js 404

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Monitor `/var/run/docker.sock` mount: now **read-write** (not `:ro`) so the control plane can restart containers and exec `pg_dump`. Every mutating endpoint is gated by `MONITOR_CONTROL_TOKEN`.
 - Deploy hook: `backend/scripts/deploy-hook.sh` is called at the end of a successful `docker-compose up -d`. Polls `/healthz` + `/health`, then appends a record to `/var/lib/astral-monitor/deploys.jsonl`. Surfaced in the "Recent deploys" block.
 
+## Production (OCI) Access
+
+- **SSH:** `ssh -i ~/.ssh/astral_oci ubuntu@astral-reader.duckdns.org` (user `ubuntu`, NOT `opc` — OCI rejects `opc` and prints "Please login as the user 'ubuntu'").
+- **Host:** `astral-server` (OCI Always Free A1 ARM instance).
+- **Compose root:** `/home/ubuntu/astral/backend/` — all `docker compose` commands must run from there. Containers are named `backend-<service>-1` (e.g., `backend-astral_monitor-1`).
+- **Env file:** `/home/ubuntu/astral/backend/.env` — add new env vars here, then `docker compose up -d --no-deps <service>` to pick them up without restarting the whole stack.
+- **Logs:** `docker compose logs -f <service>` for live tail. The monitor dashboard's Live log panel (/monitor/, AST-73) is the preferred in-browser surface.
+- **Nginx config:** lives under `/home/ubuntu/astral/backend/nginx/` and is volume-mounted into the nginx container. Reload with `docker compose exec nginx nginx -s reload` after edits.
+- **Do not run `alembic upgrade head` on prod without explicit user approval.** Read-only roles (e.g., `astral_readonly` from migration `a3b4c5d6e7f8`) need the `ASTRAL_READONLY_PASSWORD` env var set **before** the migration is applied.
+
 ## SwiftData Gotchas
 
 - **Never name a `@Model` property `description`** — conflicts with `CustomStringConvertible`. Use `comicDescription`, `fanficDescription`, etc.

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -2122,7 +2122,11 @@ refreshAll();
 setAuto(true);
 </script>
 
-<!-- control plane UI — decorated after the main renderer settles -->
-<script src="/static/controls.js"></script>
+<!-- control plane UI — decorated after the main renderer settles.
+     Relative path so the browser resolves against /monitor/ and hits the
+     FastAPI app.mount("/static", ...) inside astral_monitor. An absolute
+     "/static/..." path collides with nginx's `location /static/` block
+     (aliased to the media volume) and returns 404. -->
+<script src="static/controls.js"></script>
 </body>
 </html>

--- a/backend/nginx/nginx.conf
+++ b/backend/nginx/nginx.conf
@@ -76,7 +76,14 @@ http {
             auth_basic "astral";
             auth_basic_user_file /etc/nginx/htpasswd;
             set $monitor_upstream http://astral_monitor:8001;
-            proxy_pass $monitor_upstream/;
+            # Strip the /monitor prefix before proxying. With variable-based
+            # proxy_pass, nginx does NOT rewrite the URI automatically — a
+            # trailing "/" on the proxy_pass target silently replaced the
+            # whole request URI with "/", routing every /monitor/* path to
+            # the app root (index.html). Explicit rewrite + no-URI proxy_pass
+            # restores correct prefix stripping.
+            rewrite ^/monitor(/.*)$ $1 break;
+            proxy_pass $monitor_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_read_timeout 60;


### PR DESCRIPTION
## Summary

Two production bugs blocked every `/control/*` interaction on the OCI monitor dashboard (discovered via Playwright debugging session). Symptoms: kill switches stuck on "loading flags", SQL console no-op, audit log empty.

## Root causes

**Bug 1 — nginx `proxy_pass` silently replacing URIs.** The `/monitor/` location used `proxy_pass $monitor_upstream/;`. With a variable-based upstream plus a trailing `/` URI, nginx **replaces** the full request URI with `/` instead of stripping the `/monitor` prefix. Every `/monitor/*` request (including `/monitor/healthz`, `/monitor/control/flags`, `/monitor/static/controls.js`) was being sent to the monitor app as just `/`, which returns `index.html` with 200 OK. That's why the dashboard "worked" visually but no `/control/*` call ever reached a real handler.

Fix: explicit `rewrite ^/monitor(/.*)$ $1 break;` + `proxy_pass $monitor_upstream;` (no URI). The existing `/metrics` block was already correct and shows the right pattern.

**Bug 2 — `<script src="/static/controls.js">` hit nginx's media alias.** Absolute-from-root path conflicts with the prior `location /static/ { alias /mnt/astral-media/; }` block. Browser got a 404 HTML, so `controls.js` never executed and the panels it decorates stayed in their initial loading state — explaining all three reported symptoms in one shot.

Fix: change to relative `static/controls.js` so the browser resolves against the current `/monitor/` URL and hits `astral_monitor`'s `app.mount("/static", …)`.

## Verification from Playwright session

Every `/monitor/*` path returned the **same 111,338-byte HTML blob** — the index.html — including `/monitor/healthz` which should be `{"status":"ok"}`. That was the smoking gun for Bug 1.

## Also in this PR

- `CLAUDE.md` — new **Production (OCI) Access** section documenting the SSH entrypoint, compose root (`/home/ubuntu/astral/backend/`), env file (`.env.oci`), and common ops patterns.

## Deploy steps

1. Merge this PR to `development`.
2. On the OCI box:
   ```bash
   cd /home/ubuntu/astral/backend
   git pull
   docker compose exec nginx nginx -s reload
   ```
3. **Required before `/control/*` endpoints return anything but 503:** set `MONITOR_CONTROL_TOKEN` in `.env.oci`, then `docker compose --env-file .env.oci up -d --no-deps astral_monitor`.
4. Re-verify `/monitor/healthz` returns JSON, `/monitor/static/controls.js` returns JS, kill-switch panel populates.

## Test plan

- [ ] `/monitor/healthz` returns `{"status":"ok"}` (currently returns full index.html)
- [ ] `/monitor/static/controls.js` returns JS (currently returns index.html)
- [ ] `/monitor/control/flags` returns 503 until token set, then JSON when set (currently returns index.html)
- [ ] Browser DevTools Network tab shows `controls.js` loading 200 with JS content-type
- [ ] Kill-switch panel populates with the 3 flags after token is set
- [ ] Audit log panel shows entries after any control action

## Follow-ups (not in this PR)

- `astral_readonly` Postgres role does not exist on prod — migration `a3b4c5d6e7f8` never ran. SQL console won't work until it's applied. Needs `ASTRAL_READONLY_PASSWORD` set before the migration bakes it into the role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)