### PR TITLE
[backend] fix controls.js /control/* paths so kill switches + audit + SQL work in prod

### DIFF
--- a/backend/monitor/static/controls.js
+++ b/backend/monitor/static/controls.js
@@ -91,7 +91,7 @@
     const grid = document.getElementById('flags-grid');
     if (!grid) return;
     try {
-      const resp = await authFetch('/control/flags');
+      const resp = await authFetch('control/flags');
       if (!resp.ok) throw new Error('flags fetch failed: ' + resp.status);
       const data = await resp.json();
       grid.innerHTML = '';
@@ -120,7 +120,7 @@
             }
           }
           try {
-            const resp = await authFetch('/control/flags', {
+            const resp = await authFetch('control/flags', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({ key, value }),
@@ -167,7 +167,7 @@
     btn.disabled = true;
     btn.innerHTML = '⋯ restarting';
     try {
-      const resp = await authFetch('/control/restart/' + encodeURIComponent(svc), { method: 'POST' });
+      const resp = await authFetch('control/restart/' + encodeURIComponent(svc), { method: 'POST' });
       if (!resp.ok) throw new Error('restart failed: ' + resp.status);
       toast(svc + ' restarted', 'ok');
       loadAudit();
@@ -199,7 +199,7 @@
     btn.disabled = true;
     btn.innerHTML = '… queued';
     try {
-      const resp = await authFetch('/control/retry-job/' + encodeURIComponent(jobId), { method: 'POST' });
+      const resp = await authFetch('control/retry-job/' + encodeURIComponent(jobId), { method: 'POST' });
       if (!resp.ok) throw new Error('retry failed: ' + resp.status);
       const data = await resp.json();
       toast('re-queued as ' + data.new_job_id, 'ok');
@@ -302,7 +302,7 @@
     dl.style.marginLeft = '8px';
     dl.addEventListener('click', async () => {
       try {
-        const resp = await authFetch('/control/backup/download/latest');
+        const resp = await authFetch('control/backup/download/latest');
         if (!resp.ok) throw new Error('download failed: ' + resp.status);
         const blob = await resp.blob();
         const cd = resp.headers.get('content-disposition') || '';
@@ -323,7 +323,7 @@
     btn.disabled = true;
     btn.innerHTML = '… running';
     try {
-      const start = await authFetch('/control/backup', { method: 'POST' });
+      const start = await authFetch('control/backup', { method: 'POST' });
       if (!start.ok) {
         if (start.status === 409) throw new Error('backup already running');
         throw new Error('backup start failed: ' + start.status);
@@ -331,7 +331,7 @@
       const info = await start.json();
       const t0 = Date.now();
       const poll = async () => {
-        const st = await authFetch('/control/backup/' + info.job_id);
+        const st = await authFetch('control/backup/' + info.job_id);
         if (!st.ok) return;
         const s = await st.json();
         const secs = Math.round((Date.now() - t0) / 1000);
@@ -402,7 +402,7 @@
     status.textContent = 'running…';
     result.innerHTML = '';
     try {
-      const resp = await authFetch('/control/query', {
+      const resp = await authFetch('control/query', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sql }),
@@ -568,7 +568,7 @@
     const tbody = document.getElementById('audit-rows');
     if (!tbody) return;
     try {
-      const resp = await authFetch('/control/audit?limit=20');
+      const resp = await authFetch('control/audit?limit=20');
       if (!resp.ok) throw new Error('audit fetch failed: ' + resp.status);
       const data = await resp.json();
       if (!data.entries.length) {


### PR DESCRIPTION
## Summary

Follow-up to [#55](https://github.com/agenticCoder97/IosTestApp/pull/55). Prod testing via Playwright revealed the kill-switch panel was still showing "Flags API returned 404" and audit log "Audit API returned 404", even after the nginx + script-src fixes landed.

Root cause is the same category as the previous script-src bug: `controls.js`'s `authFetch` uses absolute paths like `'/control/flags'`, which hit nginx as `GET /control/flags` — no matching `location` block, so nginx returns 404. The correct request is `GET /monitor/control/flags`, which nginx rewrites to `/control/flags` upstream.

## Fix

Drop the leading slash on all 9 `authFetch('/control/...')` call sites. Relative paths resolve against the current `/monitor/` URL in the browser, giving the right `/monitor/control/...` request.

## Affected endpoints

- AST-70 kill switches (GET + POST flags)
- AST-71 service restart
- AST-72 ARQ retry
- AST-74 on-demand backup (start / poll / download)
- AST-75 SQL query console
- Audit log panel (GET audit)

## Not touched

`/metrics/logs/stream` and `/metrics/endpoint` use their own dedicated `location /metrics` nginx block and work whether prefixed or not.

## Test plan

- [x] After deploy, Playwright probe confirms `fetch('control/flags')` from `/monitor/` returns 200 JSON
- [x] Kill switches panel populates and toggles persist to Redis
- [x] Audit log shows previous sql.query + flags.set entries
- [x] SQL console: SELECT returns rows, DDL returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)