### PR TITLE
[backend] cache-bust controls.js after path fix

### DIFF
--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -2127,6 +2127,6 @@ setAuto(true);
      FastAPI app.mount("/static", ...) inside astral_monitor. An absolute
      "/static/..." path collides with nginx's `location /static/` block
      (aliased to the media volume) and returns 404. -->
-<script src="static/controls.js"></script>
+<script src="static/controls.js?v=3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Follow-up to [#56](https://github.com/agenticCoder97/IosTestApp/pull/56). PR #56 changed all `authFetch('/control/...')` → `authFetch('control/...')` in controls.js. The server serves the new file correctly (verified via Playwright direct fetch), but the **browser was running the OLD cached controls.js** because the script src URL didn't change, so `loadFlags()` still hit `/control/flags` (404).

## Fix

Append `?v=3` to the script src. Browser treats it as a fresh resource and fetches the post-#56 bytes.

## Test plan

- [x] After deploy, Playwright probe confirms the `flags-grid` element fills with the 3 kill switches (`MANGADEX_DISABLED`, `FFNET_NEW_SCRAPER_DISABLED`, `MANGADEX_AUTO_SWITCH_SOURCE`)
- [x] `audit-rows` panel shows real audit entries
- [x] Zero `Failed to load resource` errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)