### PR TITLE
[backend] AST-77 wire deploy-hook.sh into deploy workflow + fix probe URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,11 +42,12 @@ jobs:
           DEPLOY_APP: ${{ steps.changes.outputs.app }}
           DEPLOY_NGINX: ${{ steps.changes.outputs.nginx }}
           BUILD_SHA: ${{ github.sha }}
+          GHA_ACTOR: ${{ github.actor }}
         with:
           host: astral-reader.duckdns.org
           username: ubuntu
           key: ${{ secrets.ASTRAL_OCI_SSH_KEY }}
-          envs: DEPLOY_MONITOR,DEPLOY_APP,DEPLOY_NGINX,BUILD_SHA
+          envs: DEPLOY_MONITOR,DEPLOY_APP,DEPLOY_NGINX,BUILD_SHA,GHA_ACTOR
           script_stop: true
           script: |
             set -euo pipefail
@@ -57,23 +58,35 @@ jobs:
             git clean -fd
             cd backend
             SHORT_SHA=${BUILD_SHA::7}
+            STARTED_EPOCH=$(date +%s)
+            IMAGES=""
 
             if [ "$DEPLOY_APP" = "true" ]; then
               echo "==> Rebuilding fastapi + arq_worker"
               docker compose build fastapi arq_worker
               docker compose up -d --no-deps fastapi arq_worker
+              IMAGES="${IMAGES} fastapi:${SHORT_SHA} arq_worker:${SHORT_SHA}"
             fi
 
             if [ "$DEPLOY_MONITOR" = "true" ]; then
               echo "==> Rebuilding astral_monitor (sha=${SHORT_SHA})"
               MONITOR_BUILD_SHA=${SHORT_SHA} docker compose build astral_monitor
               docker compose up -d --no-deps astral_monitor
+              IMAGES="${IMAGES} astral_monitor:${SHORT_SHA}"
             fi
 
             if [ "$DEPLOY_NGINX" = "true" ]; then
               echo "==> Reloading nginx config"
               docker compose exec -T nginx nginx -s reload
+              IMAGES="${IMAGES} nginx:reload"
             fi
 
             echo "==> Service status"
             docker compose ps --format 'table {{.Name}}\t{{.Status}}'
+
+            echo "==> Recording deploy via hook (AST-77)"
+            bash scripts/deploy-hook.sh \
+              --images        "${IMAGES# }" \
+              --started-epoch "$STARTED_EPOCH" \
+              --commit-sha    "$SHORT_SHA" \
+              --actor         "${GHA_ACTOR:-unknown}"

--- a/backend/scripts/deploy-hook.sh
+++ b/backend/scripts/deploy-hook.sh
@@ -13,12 +13,19 @@
 #       --actor        "$GITHUB_ACTOR"
 #
 # Healthiness is computed by polling the astral_monitor /healthz and
-# the fastapi /health endpoints for up to 60 s.
+# the fastapi /api/v1/health endpoints for up to 60 s. Probes run from
+# inside the `nginx` container so docker-internal DNS works — neither
+# service is reachable from the OCI host directly (monitor only
+# `expose`s 8001; host port 80 redirects to HTTPS which is served on
+# a different server_name).
+#
+# Must be executed from the directory containing docker-compose.yml.
 
 set -euo pipefail
 
 MONITOR_STATE_DIR="${MONITOR_STATE_DIR:-/var/lib/astral-monitor}"
 DEPLOY_LOG="${MONITOR_STATE_DIR}/deploys.jsonl"
+COMPOSE="${COMPOSE:-docker compose --env-file .env.oci}"
 
 images=""
 started_epoch="$(date +%s)"
@@ -37,9 +44,14 @@ done
 
 healthy=true
 end=$(( $(date +%s) + 60 ))
+probe_monitor() {
+  $COMPOSE exec -T nginx curl -fsS --max-time 3 http://astral_monitor:8001/healthz >/dev/null 2>&1
+}
+probe_fastapi() {
+  $COMPOSE exec -T nginx curl -fsS --max-time 3 http://fastapi:8000/api/v1/health >/dev/null 2>&1
+}
 while [[ $(date +%s) -lt $end ]]; do
-  if curl -fsS --max-time 3 "http://127.0.0.1:8001/healthz" >/dev/null 2>&1 \
-     && curl -fsS --max-time 3 "http://127.0.0.1/health"   >/dev/null 2>&1; then
+  if probe_monitor && probe_fastapi; then
     healthy=true
     break
   fi
@@ -60,12 +72,20 @@ if [[ -n "$images" ]]; then
   ')
 fi
 
-mkdir -p "$MONITOR_STATE_DIR"
-
 record=$(cat <<EOF
 {"ts":"$ts","images_pulled":$images_json,"healthy":$healthy,"duration_s":$duration_s,"commit_sha":"$commit_sha","actor":"$actor"}
 EOF
 )
 
-echo "$record" >> "$DEPLOY_LOG"
-echo "deploy-hook: recorded $record"
+# Append via docker exec so the write lands inside the monitor_state
+# volume (mounted at $MONITOR_STATE_DIR in astral_monitor). The host's
+# path is the root-owned docker volume dir — ubuntu can't write there
+# without sudo. Non-fatal: a log write failure should not fail the
+# whole deploy.
+if printf '%s\n' "$record" | $COMPOSE exec -T astral_monitor \
+    sh -c "mkdir -p '$MONITOR_STATE_DIR' && cat >> '$DEPLOY_LOG'"; then
+  echo "deploy-hook: recorded $record"
+else
+  echo "deploy-hook: WARNING — could not append to $DEPLOY_LOG (monitor container down?)" >&2
+  echo "deploy-hook: record was $record" >&2
+fi


### PR DESCRIPTION
## Summary

Completes the AST-77 acceptance criterion #1 follow-up: the deploy workflow now calls `backend/scripts/deploy-hook.sh` after each deploy, and the hook's health probes + log-write path are fixed so the Recent Deploys block on the monitor dashboard actually populates.

## Three bugs, one PR

| # | File | Bug | Fix |
|---|---|---|---|
| 1 | `.github/workflows/deploy.yml` | Hook was never called | Invoke at end of deploy step with `--images / --started-epoch / --commit-sha / --actor`. `GITHUB_ACTOR` threaded through `env:` for script safety. |
| 2 | `backend/scripts/deploy-hook.sh` | `curl http://127.0.0.1:8001/healthz` & `curl http://127.0.0.1/health` — neither path was reachable from the OCI host (monitor is `expose`d only; port 80 redirects to HTTPS; real route is `/api/v1/health`). Every recorded deploy would have been `healthy:false`. | Probe via `docker compose exec -T nginx curl` using docker-internal DNS: `http://astral_monitor:8001/healthz` and `http://fastapi:8000/api/v1/health`. |
| 3 | `backend/scripts/deploy-hook.sh` | Script appended to `/var/lib/astral-monitor/deploys.jsonl` from the host — that's the root-owned docker-volume mount path, ubuntu can't write. | Pipe the record via `docker compose exec -T astral_monitor sh -c "... cat >> $DEPLOY_LOG"` so the write lands inside the container. Non-fatal on failure — deploy shouldn't fail just because the audit log couldn't be appended. |

## End-to-end verification (done on prod before opening this PR)

1. scp'd the updated hook to `/tmp/deploy-hook-test.sh` on the OCI box
2. Ran it with `--images "fastapi:test123 arq_worker:test123" --started-epoch $(($(date +%s) - 5)) --commit-sha test123 --actor claude-test`
3. Hook printed `deploy-hook: recorded {"ts":...,"healthy":true,"duration_s":5,...}`
4. `docker compose exec astral_monitor cat /var/lib/astral-monitor/deploys.jsonl` — record present
5. `GET /metrics?range=1h` returned the record in `data.deploys.recent` — dashboard would render it
6. Cleaned up the test entry (`rm deploys.jsonl; touch deploys.jsonl`)

## Test plan for this PR

- [ ] Merge → push triggers the workflow
- [ ] SSH log of the deploy step shows `==> Recording deploy via hook (AST-77)` and `deploy-hook: recorded {...}`
- [ ] Monitor dashboard's **Recent Deploys** block shows the merge commit with actor, short SHA, duration, `healthy:true`
- [ ] `docker compose exec astral_monitor cat /var/lib/astral-monitor/deploys.jsonl` shows the record

Fixes AST-77

🤖 Generated with [Claude Code](https://claude.com/claude-code)