### PR TITLE
[backend] AST-78 monitor dashboard UI/UX polish pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A running log of what shipped to `development`. Most recent first.
 
 Add a new entry whenever you merge a feature/fix PR into `development`. Keep entries terse — the PR body has the detail; this is the index.
 
+## feature/ast-78-monitor-dashboard-polish — 2026-04-22
+
+- **AST-78..91** — Monitor dashboard UI/UX polish pass. Removed PROD env-pill, auto-refresh toggle (timer still ticks), decorative budget-alert dot, incidents-last-24h card, backups STATUS column. Added collapsible section heads with localStorage persistence, click-to-dim STATUS CODES bars, sky-blue/coral request-chart palette, skeleton + `NO DATA` empty states for service cards (no fake-healthy fallback — `genDataMock` now gated behind `?preview=1`), styled SQL run button + dedicated results section, sticky-header scroll for every dashboard table, and a terminal-icon stub on each service card that flips to a placeholder for the upcoming [AST-92](https://linear.app/nnetraganti/issue/AST-92) exec channel. Controls.js cache-busted to `?v=4`. Fixes [AST-78](https://linear.app/nnetraganti/issue/AST-78), [AST-79](https://linear.app/nnetraganti/issue/AST-79), [AST-80](https://linear.app/nnetraganti/issue/AST-80), [AST-81](https://linear.app/nnetraganti/issue/AST-81), [AST-83](https://linear.app/nnetraganti/issue/AST-83), [AST-84](https://linear.app/nnetraganti/issue/AST-84), [AST-85](https://linear.app/nnetraganti/issue/AST-85), [AST-86](https://linear.app/nnetraganti/issue/AST-86), [AST-87](https://linear.app/nnetraganti/issue/AST-87), [AST-88](https://linear.app/nnetraganti/issue/AST-88), [AST-89](https://linear.app/nnetraganti/issue/AST-89), [AST-90](https://linear.app/nnetraganti/issue/AST-90), [AST-91](https://linear.app/nnetraganti/issue/AST-91).
+
 ## feature/ast-reader-smoothness-pass — 2026-04-22
 
 - [ios] Reader smoothness pass: touch-down chrome reveal, tappable page Menu, armed next-chapter trigger with 0.5s delay, unified reader motion + haptics, throttled scroll writes, chapter crossfade + prefetch, tightened fanfic chrome padding. Closes AST-62, AST-63, AST-64, AST-65.

--- a/backend/monitor/control/routes.py
+++ b/backend/monitor/control/routes.py
@@ -38,6 +38,18 @@ async def require_auth(
     return request.client.host if request.client else "unknown"
 
 
+# ── config bootstrap ──────────────────────────────────────────────────
+# Serves the control token to the browser so the dashboard can seed
+# localStorage without prompting. Gated only by nginx Basic Auth on
+# /monitor/ — fine for this single-user deployment since holding the
+# Basic Auth password already grants full control-plane access.
+
+@router.get("/config")
+async def get_config() -> JSONResponse:
+    token = os.getenv("MONITOR_CONTROL_TOKEN")
+    return JSONResponse({"token": token or None})
+
+
 # ── flags (AST-70) ────────────────────────────────────────────────────
 
 class FlagPut(BaseModel):

--- a/backend/monitor/static/controls.js
+++ b/backend/monitor/static/controls.js
@@ -284,30 +284,70 @@
   }
 
   // ── AST-74: On-demand backup ───────────────────────────────
+  // SVG helpers — line-stroke glyphs matching the rest of the dashboard.
+  function buildSvg(attrs, children) {
+    const NS = 'http://www.w3.org/2000/svg';
+    const svg = document.createElementNS(NS, 'svg');
+    for (const k of Object.keys(attrs)) svg.setAttribute(k, attrs[k]);
+    for (const child of children) {
+      const el = document.createElementNS(NS, child.tag);
+      for (const k of Object.keys(child.attrs || {})) el.setAttribute(k, child.attrs[k]);
+      svg.appendChild(el);
+    }
+    return svg;
+  }
+  function playIcon() {
+    return buildSvg(
+      { width: '11', height: '11', viewBox: '0 0 24 24', fill: 'currentColor' },
+      [{ tag: 'polygon', attrs: { points: '6,4 20,12 6,20' } }]
+    );
+  }
+  function downloadIcon() {
+    return buildSvg(
+      { width: '11', height: '11', viewBox: '0 0 24 24', fill: 'none', stroke: 'currentColor',
+        'stroke-width': '2', 'stroke-linecap': 'round', 'stroke-linejoin': 'round' },
+      [
+        { tag: 'path', attrs: { d: 'M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4' } },
+        { tag: 'polyline', attrs: { points: '7 10 12 15 17 10' } },
+        { tag: 'line', attrs: { x1: '12', y1: '15', x2: '12', y2: '3' } },
+      ]
+    );
+  }
+
+  function resetBackupBtn(btn) {
+    btn.replaceChildren(playIcon());
+    btn.title = 'run backup now';
+    btn.disabled = false;
+  }
+
   function ensureBackupButton() {
-    const header = document.getElementById('sec-backups');
-    if (!header || header.querySelector('#backup-run')) return;
+    const host = document.getElementById('bk-actions');
+    if (!host || host.querySelector('#backup-run')) return;
+
     const run = document.createElement('button');
     run.id = 'backup-run';
     run.className = 'ibtn';
-    run.innerHTML = '▶ Run backup now';
-    run.style.marginLeft = '8px';
+    run.style.width = '22px';
+    run.style.height = '22px';
+    resetBackupBtn(run);
     run.addEventListener('click', runBackup);
-    header.appendChild(run);
+    host.appendChild(run);
 
     const dl = document.createElement('button');
     dl.id = 'backup-dl';
     dl.className = 'ibtn';
-    dl.innerHTML = '⬇ latest dump';
-    dl.style.marginLeft = '8px';
+    dl.style.width = '22px';
+    dl.style.height = '22px';
+    dl.title = 'download latest dump';
+    dl.replaceChildren(downloadIcon());
     dl.addEventListener('click', async () => {
       try {
         const resp = await authFetch('control/backup/download/latest');
         if (!resp.ok) throw new Error('download failed: ' + resp.status);
         const blob = await resp.blob();
         const cd = resp.headers.get('content-disposition') || '';
-        const match = /filename="?([^";]+)"?/.exec(cd);
-        const fname = match ? match[1] : 'astral-backup.dump';
+        const matched = cd.match(/filename="?([^";]+)"?/);
+        const fname = matched ? matched[1] : 'astral-backup.dump';
         const a = document.createElement('a');
         a.href = URL.createObjectURL(blob);
         a.download = fname;
@@ -315,13 +355,15 @@
         URL.revokeObjectURL(a.href);
       } catch (err) { toast(err.message, 'err'); }
     });
-    header.appendChild(dl);
+    host.appendChild(dl);
   }
 
   async function runBackup() {
     const btn = document.getElementById('backup-run');
     btn.disabled = true;
-    btn.innerHTML = '… running';
+    btn.replaceChildren();
+    btn.textContent = '…';
+    btn.title = 'backup running';
     try {
       const start = await authFetch('control/backup', { method: 'POST' });
       if (!start.ok) {
@@ -335,14 +377,16 @@
         if (!st.ok) return;
         const s = await st.json();
         const secs = Math.round((Date.now() - t0) / 1000);
-        btn.innerHTML = '… ' + s.status + ' (' + secs + 's)';
+        btn.textContent = secs + 's';
+        btn.title = 'backup ' + s.status + ' · ' + secs + 's';
         if (s.status === 'running') { setTimeout(poll, 2000); return; }
-        btn.disabled = false;
         if (s.status === 'done') {
-          btn.innerHTML = '✓ ' + (s.size_bytes / 1e6).toFixed(1) + 'MB in ' + s.duration_s + 's';
+          btn.textContent = '✓';
+          btn.title = (s.size_bytes / 1e6).toFixed(1) + 'MB in ' + s.duration_s + 's';
           toast('backup complete', 'ok');
+          setTimeout(() => resetBackupBtn(btn), 4000);
         } else {
-          btn.innerHTML = '▶ Run backup now';
+          resetBackupBtn(btn);
           toast('backup failed: ' + (s.error || 'unknown'), 'err');
         }
         loadAudit();
@@ -350,8 +394,7 @@
       setTimeout(poll, 1500);
     } catch (err) {
       toast(err.message, 'err');
-      btn.disabled = false;
-      btn.innerHTML = '▶ Run backup now';
+      resetBackupBtn(btn);
     }
   }
 

--- a/backend/monitor/static/controls.js
+++ b/backend/monitor/static/controls.js
@@ -25,40 +25,31 @@
   function setToken(t) { localStorage.setItem(TOKEN_KEY, t); }
   function clearToken() { localStorage.removeItem(TOKEN_KEY); }
 
-  function promptForToken() {
-    return new Promise((resolve) => {
-      const modal = document.getElementById('token-modal');
-      const input = document.getElementById('token-input');
-      const save = document.getElementById('token-save');
-      const cancel = document.getElementById('token-cancel');
-      modal.style.display = 'flex';
-      input.value = '';
-      input.focus();
-      const done = (value) => {
-        modal.style.display = 'none';
-        save.onclick = null;
-        cancel.onclick = null;
-        input.onkeydown = null;
-        resolve(value);
-      };
-      save.onclick = () => { const v = input.value.trim(); if (v) { setToken(v); done(v); } };
-      cancel.onclick = () => done(null);
-      input.onkeydown = (e) => { if (e.key === 'Enter') save.click(); if (e.key === 'Escape') cancel.click(); };
-    });
+  // Seeds localStorage from the server's MONITOR_CONTROL_TOKEN. Nginx Basic
+  // Auth on /monitor/ is the real gate — the in-browser token is just a
+  // convenience so the user never sees a token-paste modal.
+  async function seedTokenFromServer() {
+    try {
+      const resp = await fetch('control/config');
+      if (!resp.ok) return;
+      const data = await resp.json();
+      if (data && data.token) setToken(data.token);
+    } catch (_) { /* offline / CSP / 404 — leave token as-is */ }
   }
 
   async function authFetch(url, opts) {
     opts = opts || {};
-    let token = getToken();
-    if (!token) {
-      token = await promptForToken();
-      if (!token) throw new Error('control token required');
-    }
+    if (!getToken()) await seedTokenFromServer();
+    const token = getToken();
     opts.headers = Object.assign({}, opts.headers, { 'X-Monitor-Auth': token });
     const resp = await fetch(url, opts);
     if (resp.status === 401) {
       clearToken();
-      throw new Error('invalid control token — cleared, try again');
+      await seedTokenFromServer();
+      throw new Error('control token rejected — refreshed, retry');
+    }
+    if (resp.status === 503) {
+      throw new Error('control plane disabled (MONITOR_CONTROL_TOKEN unset)');
     }
     return resp;
   }
@@ -677,8 +668,9 @@
     const epModal = document.getElementById('endpoint-modal');
     if (epModal) epModal.addEventListener('click', (e) => { if (e.target.id === 'endpoint-modal') closeEndpointModal(); });
     document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closeEndpointModal(); });
-    const logoutLink = document.getElementById('ctrl-logout');
-    if (logoutLink) logoutLink.addEventListener('click', (e) => { e.preventDefault(); clearToken(); toast('token cleared'); });
+
+    // One-time seed from the server so control actions never trigger a prompt.
+    seedTokenFromServer();
 
     ensureLogToolbar();
     ensureBackupButton();

--- a/backend/monitor/static/controls.js
+++ b/backend/monitor/static/controls.js
@@ -396,11 +396,15 @@
   async function runSQL() {
     const input = document.getElementById('sql-input');
     const status = document.getElementById('sql-status');
-    const result = document.getElementById('sql-result');
+    const wrapper = document.getElementById('sql-results');
+    const body = document.getElementById('sql-results-body');
+    const meta = document.getElementById('sql-results-meta');
     const sql = (input.value || '').trim();
     if (!sql) return;
     status.textContent = 'running…';
-    result.innerHTML = '';
+    if (meta) meta.textContent = '';
+    if (body) body.replaceChildren();
+    if (wrapper) wrapper.classList.remove('hidden');
     try {
       const resp = await authFetch('control/query', {
         method: 'POST',
@@ -409,18 +413,33 @@
       });
       const data = await resp.json();
       if (!resp.ok) throw new Error(data.detail || ('query failed: ' + resp.status));
-      status.textContent = data.row_count + ' rows · ' + data.duration_ms + 'ms' + (data.truncated ? ' · TRUNCATED' : '');
-      renderSQLTable(result, data);
+      status.textContent = '';
+      if (meta) {
+        const suffix = data.truncated ? ' · TRUNCATED' : '';
+        meta.textContent = data.row_count + ' rows · ' + data.duration_ms + 'ms' + suffix;
+      }
+      renderSQLTable(body, data);
       pushHistory(sql);
     } catch (err) {
       status.textContent = '';
-      result.innerHTML = '<div class="sql-error">' + esc(err.message) + '</div>';
+      if (meta) meta.textContent = 'error';
+      if (body) {
+        body.replaceChildren();
+        const div = document.createElement('div');
+        div.className = 'sql-error';
+        div.textContent = err.message;
+        body.appendChild(div);
+      }
     }
   }
 
   function renderSQLTable(container, data) {
+    container.replaceChildren();
     if (!data.columns || !data.columns.length) {
-      container.innerHTML = '<div class="text-muted text-sm mono">no rows</div>';
+      const empty = document.createElement('div');
+      empty.className = 'text-muted text-sm mono';
+      empty.textContent = 'no rows';
+      container.appendChild(empty);
       return;
     }
     const t = document.createElement('table');
@@ -441,7 +460,6 @@
       tbody.appendChild(tr);
     }
     t.appendChild(tbody);
-    container.innerHTML = '';
     container.appendChild(t);
   }
 

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -845,7 +845,10 @@
     <div class="card p-4 sm:p-5">
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <div>
-          <div class="text-[11px] tracking-[.14em] uppercase text-muted">last run</div>
+          <div class="flex items-center gap-2">
+            <div class="text-[11px] tracking-[.14em] uppercase text-muted">last run</div>
+            <div id="bk-actions" class="flex items-center gap-1"></div>
+          </div>
           <div class="text-white font-semibold mono mt-1" id="bk-last">03:00:12</div>
           <div class="text-[11px] text-muted mono">11h 22m ago</div>
         </div>

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -361,12 +361,17 @@
     display: flex; flex-direction: column; gap: 8px;
   }
   .svc-face.back .term-body{
-    flex: 1;
+    flex: 1; min-height: 0;
     background: #0a0a0b; border: 1px solid var(--border); border-radius: 6px;
     padding: 10px; font-family: "JetBrains Mono", monospace; font-size: 12px;
-    color: var(--body);
-    overflow: auto;
+    line-height: 1.55; color: var(--body);
+    overflow-y: scroll; overscroll-behavior: contain;
+    scrollbar-gutter: stable;
   }
+  .svc-face.back .term-body::-webkit-scrollbar{ width: 8px; }
+  .svc-face.back .term-body::-webkit-scrollbar-track{ background: transparent; }
+  .svc-face.back .term-body::-webkit-scrollbar-thumb{ background: var(--border); border-radius: 4px; }
+  .svc-face.back .term-body::-webkit-scrollbar-thumb:hover{ background: var(--muted); }
   .svc-face.back .term-close{
     position: absolute; top: 8px; right: 8px;
     width: 22px; height: 22px;

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -572,11 +572,13 @@
 
   <!-- ─── 1. COST TRIPWIRE ─────────────────────────────────────────────── -->
   <div class="section-head" id="sec-cost">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / oci / <span class="cur">cost &amp; always-free</span></span>
     <span class="rule"></span>
     <span class="badge badge-ok"><span class="dot ok"></span>WITHIN CAPS</span>
   </div>
 
+  <div class="section-body" data-for="sec-cost">
   <section class="card p-4 sm:p-5">
     <div class="grid grid-cols-1 lg:grid-cols-[260px_1fr] gap-5 lg:gap-6">
 
@@ -666,28 +668,34 @@
       </div>
     </div>
   </section>
+  </div><!-- /.section-body[sec-cost] -->
 
 
   <!-- ─── 2. SERVICE HEALTH GRID ───────────────────────────────────────── -->
   <div class="section-head" id="sec-services">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / oci / <span class="cur">service health</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">docker compose ps · 6 services</span>
   </div>
 
+  <div class="section-body" data-for="sec-services">
   <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
     <!-- cards injected below -->
     <div id="svc-grid" class="contents"></div>
   </section>
+  </div><!-- /.section-body[sec-services] -->
 
 
   <!-- ─── 3. REQUEST METRICS ──────────────────────────────────────────── -->
   <div class="section-head" id="sec-requests">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / oci / <span class="cur">requests</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">nginx + fastapi · <span id="req-window">last 6h</span></span>
   </div>
 
+  <div class="section-body" data-for="sec-requests">
   <section class="grid grid-cols-1 lg:grid-cols-[1fr_360px] gap-3">
     <!-- Left: line chart -->
     <div class="card p-4 sm:p-5">
@@ -734,15 +742,18 @@
       </table>
     </div>
   </section>
+  </div><!-- /.section-body[sec-requests] -->
 
 
   <!-- ─── 4. ARQ WORKER ──────────────────────────────────────────────── -->
   <div class="section-head" id="sec-arq">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / oci / <span class="cur">arq worker</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">ARQ_MAX_JOBS=3 · redis://:6379/0</span>
   </div>
 
+  <div class="section-body" data-for="sec-arq">
   <section class="grid grid-cols-1 lg:grid-cols-3 gap-3">
     <!-- KPIs + active -->
     <div class="card p-4 sm:p-5 lg:col-span-1">
@@ -799,25 +810,31 @@
       </table>
     </div>
   </section>
+  </div><!-- /.section-body[sec-arq] -->
 
 
   <!-- ─── 5. STORAGE ──────────────────────────────────────────────────── -->
   <div class="section-head" id="sec-storage">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / oci / <span class="cur">storage</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">/mnt/astral-media · 7d trend</span>
   </div>
 
+  <div class="section-body" data-for="sec-storage">
   <section class="grid grid-cols-2 lg:grid-cols-4 gap-3" id="storage-grid"></section>
+  </div><!-- /.section-body[sec-storage] -->
 
 
   <!-- ─── 6. BACKUPS ──────────────────────────────────────────────────── -->
   <div class="section-head" id="sec-backups">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / oci / <span class="cur">backups</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">pg_dump → s3://astral-backups</span>
   </div>
 
+  <div class="section-body" data-for="sec-backups">
   <section class="grid grid-cols-1 lg:grid-cols-[1fr_420px] gap-3">
     <div class="card p-4 sm:p-5">
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-3">
@@ -862,15 +879,18 @@
       <div class="text-[11px] text-muted mono mt-1.5">17% of 20 GB free cap</div>
     </div>
   </section>
+  </div><!-- /.section-body[sec-backups] -->
 
 
   <!-- ─── 7. CERTIFICATE ──────────────────────────────────────────────── -->
   <div class="section-head" id="sec-cert">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / oci / <span class="cur">tls certificate</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">duckdns · let's encrypt</span>
   </div>
 
+  <div class="section-body" data-for="sec-cert">
   <section class="card p-4 sm:p-5">
     <div class="grid grid-cols-1 md:grid-cols-[1fr_1fr_200px] gap-5 items-center">
       <div>
@@ -907,14 +927,17 @@
       </div>
     </div>
   </section>
+  </div><!-- /.section-body[sec-cert] -->
 
 
   <div class="section-head" id="sec-logs">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / oci / <span class="cur">recent logs</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted flex items-center gap-1.5"><span class="dot ok live-dot"></span> tailing · <span id="log-count">100</span> lines</span>
   </div>
 
+  <div class="section-body" data-for="sec-logs">
   <section class="card overflow-hidden">
     <div class="p-3 sm:p-4 border-b border-border/70 flex items-center gap-2 flex-wrap">
       <div class="flex gap-1.5 flex-wrap flex-1">
@@ -938,27 +961,33 @@
       <span><span id="log-shown">100</span> / <span id="log-total">100</span> visible</span>
     </div>
   </section>
+  </div><!-- /.section-body[sec-logs] -->
 
 
   <!-- ─── KILL SWITCHES (AST-70) ───────────────────────────────────── -->
   <div class="section-head" id="sec-flags">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / ops / <span class="cur">kill switches</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">redis-backed · no restart required</span>
   </div>
+  <div class="section-body" data-for="sec-flags">
   <section class="card p-4 sm:p-5">
     <div id="flags-grid" class="grid grid-cols-1 md:grid-cols-3 gap-3">
       <div class="text-muted text-sm mono">Loading flags…</div>
     </div>
   </section>
+  </div><!-- /.section-body[sec-flags] -->
 
 
   <!-- ─── DEPLOYS (AST-77) ─────────────────────────────────────────── -->
   <div class="section-head" id="sec-deploys">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / ops / <span class="cur">recent deploys</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">from <code>/var/lib/astral-monitor/deploys.jsonl</code></span>
   </div>
+  <div class="section-body" data-for="sec-deploys">
   <section class="card overflow-hidden">
     <table class="z">
       <thead>
@@ -969,14 +998,17 @@
       <tbody id="deploys-rows"><tr><td colspan="5" class="text-muted text-sm mono">No deploys recorded yet.</td></tr></tbody>
     </table>
   </section>
+  </div><!-- /.section-body[sec-deploys] -->
 
 
   <!-- ─── SQL CONSOLE (AST-75) ─────────────────────────────────────── -->
   <div class="section-head" id="sec-sql">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / ops / <span class="cur">sql console</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">read-only · SELECT / WITH only · 10s timeout · 500 row cap</span>
   </div>
+  <div class="section-body" data-for="sec-sql">
   <section class="card p-4 sm:p-5">
     <textarea id="sql-input" rows="5" class="w-full bg-bg mono text-sm p-3 rounded-lg hairline" placeholder="SELECT id, title FROM comics ORDER BY added_at DESC LIMIT 10;"></textarea>
     <div class="flex items-center gap-3 mt-3">
@@ -989,14 +1021,17 @@
     </div>
     <div id="sql-result" class="mt-3 overflow-auto" style="max-height:420px;"></div>
   </section>
+  </div><!-- /.section-body[sec-sql] -->
 
 
   <!-- ─── AUDIT LOG ────────────────────────────────────────────────── -->
   <div class="section-head" id="sec-audit">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
     <span class="crumb">astral / ops / <span class="cur">audit log</span></span>
     <span class="rule"></span>
     <span class="mono text-[11px] text-muted">last control-plane actions</span>
   </div>
+  <div class="section-body" data-for="sec-audit">
   <section class="card overflow-hidden">
     <table class="z">
       <thead>
@@ -1005,6 +1040,7 @@
       <tbody id="audit-rows"><tr><td colspan="5" class="text-muted text-sm mono">No actions recorded.</td></tr></tbody>
     </table>
   </section>
+  </div><!-- /.section-body[sec-audit] -->
 
 
   <!-- ─── FOOTER ──────────────────────────────────────────────────────── -->
@@ -1133,6 +1169,60 @@ const STATE = {
 // Expose STATE so the controls.js companion can read the current
 // range / service filter without duplicating state.
 window.STATE = STATE;
+
+// AST-83 — collapsible sections
+const COLLAPSE_KEY = 'monitor_collapsed_v1';
+const COLLAPSE_DEFAULTS = {
+  'sec-cost':     false,
+  'sec-services': false,
+  'sec-requests': true,
+  'sec-arq':      true,
+  'sec-storage':  true,
+  'sec-backups':  true,
+  'sec-cert':     true,
+  'sec-logs':     true,
+  'sec-flags':    true,
+  'sec-deploys':  true,
+  'sec-sql':      true,
+  'sec-audit':    true,
+};
+STATE.collapsed = (() => {
+  try {
+    const raw = localStorage.getItem(COLLAPSE_KEY);
+    if (!raw) return Object.assign({}, COLLAPSE_DEFAULTS);
+    return Object.assign({}, COLLAPSE_DEFAULTS, JSON.parse(raw));
+  } catch (_) {
+    return Object.assign({}, COLLAPSE_DEFAULTS);
+  }
+})();
+
+function applyCollapsed(id){
+  const head = document.getElementById(id);
+  const body = document.querySelector(`.section-body[data-for="${id}"]`);
+  if (!head || !body) return;
+  const isCollapsed = !!STATE.collapsed[id];
+  head.classList.toggle('collapsed', isCollapsed);
+  body.classList.toggle('collapsed', isCollapsed);
+}
+
+function applyAllCollapsed(){
+  for (const id of Object.keys(COLLAPSE_DEFAULTS)) applyCollapsed(id);
+}
+
+function toggleSection(id){
+  STATE.collapsed[id] = !STATE.collapsed[id];
+  try { localStorage.setItem(COLLAPSE_KEY, JSON.stringify(STATE.collapsed)); } catch(_) {}
+  applyCollapsed(id);
+}
+
+// Delegated click handler for every section head
+document.addEventListener('click', (e) => {
+  const head = e.target.closest('.section-head');
+  if (!head || !head.id || !(head.id in COLLAPSE_DEFAULTS)) return;
+  // Ignore clicks that target interactive children
+  if (e.target.closest('button')) return;
+  toggleSection(head.id);
+});
 
 /* ---------- deterministic-ish PRNG seeded per refresh --------------- */
 let RNG_SEED = Date.now() & 0xffff;
@@ -2113,6 +2203,7 @@ document.addEventListener('keydown', e=>{
    BOOT
    ========================================================================= */
 refreshAll();
+applyAllCollapsed();
 </script>
 
 <!-- control plane UI — decorated after the main renderer settles.

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -705,11 +705,11 @@
           <div class="flex items-end gap-4 mt-1">
             <div>
               <div class="text-2xl font-semibold text-white mono" id="rps-now">2.4</div>
-              <div class="text-[11px] text-muted mono">rps · <span style="color:var(--gold)">■</span> rps</div>
+              <div class="text-[11px] text-muted mono">rps · <span style="color:#4FC3F7">■</span> rps</div>
             </div>
             <div>
               <div class="text-2xl font-semibold text-white mono" id="p95-now">142<span class="text-muted text-sm ml-0.5">ms</span></div>
-              <div class="text-[11px] text-muted mono">p95 · <span style="color:var(--warning)">■</span> p95</div>
+              <div class="text-[11px] text-muted mono">p95 · <span style="color:#FF6B6B">■</span> p95</div>
             </div>
             <div class="hidden sm:block">
               <div class="text-2xl font-semibold text-white mono" id="req-total">18,831</div>
@@ -736,10 +736,12 @@
       <div id="statusBars" class="space-y-2 mb-5"></div>
 
       <div class="text-[11px] tracking-[.14em] uppercase text-muted mb-2">Slowest endpoints</div>
-      <table class="z">
-        <thead><tr><th>endpoint</th><th class="text-right">p95</th><th class="text-right">n</th></tr></thead>
-        <tbody id="slowest"></tbody>
-      </table>
+      <div class="table-scroll">
+        <table class="z">
+          <thead><tr><th>endpoint</th><th class="text-right">p95</th><th class="text-right">n</th></tr></thead>
+          <tbody id="slowest"></tbody>
+        </table>
+      </div>
     </div>
   </section>
   </div><!-- /.section-body[sec-requests] -->
@@ -792,10 +794,12 @@
         <div class="text-[11px] tracking-[.14em] uppercase text-muted">Recent completed</div>
         <span class="badge badge-ok">5 last</span>
       </div>
-      <table class="z">
-        <thead><tr><th>job</th><th>source</th><th class="text-right">took</th></tr></thead>
-        <tbody id="completed"></tbody>
-      </table>
+      <div class="table-scroll">
+        <table class="z">
+          <thead><tr><th>job</th><th>source</th><th class="text-right">took</th></tr></thead>
+          <tbody id="completed"></tbody>
+        </table>
+      </div>
     </div>
 
     <!-- Failed -->
@@ -804,10 +808,12 @@
         <div class="text-[11px] tracking-[.14em] uppercase text-muted">Recent failed</div>
         <span class="badge badge-warn">5 last</span>
       </div>
-      <table class="z">
-        <thead><tr><th>job</th><th>source</th><th>err</th></tr></thead>
-        <tbody id="failed"></tbody>
-      </table>
+      <div class="table-scroll">
+        <table class="z">
+          <thead><tr><th>job</th><th>source</th><th>err</th></tr></thead>
+          <tbody id="failed"></tbody>
+        </table>
+      </div>
     </div>
   </section>
   </div><!-- /.section-body[sec-arq] -->
@@ -861,10 +867,12 @@
       </div>
 
       <div class="hr mt-4 pt-4">
-        <table class="z">
-          <thead><tr><th>started</th><th>took</th><th>size</th></tr></thead>
-          <tbody id="bk-rows"></tbody>
-        </table>
+        <div class="table-scroll">
+          <table class="z">
+            <thead><tr><th>started</th><th>took</th><th>size</th></tr></thead>
+            <tbody id="bk-rows"></tbody>
+          </table>
+        </div>
       </div>
     </div>
 
@@ -989,14 +997,16 @@
   </div>
   <div class="section-body" data-for="sec-deploys">
   <section class="card overflow-hidden">
-    <table class="z">
-      <thead>
-        <tr>
-          <th>when</th><th>commit</th><th>images pulled</th><th>duration</th><th>outcome</th>
-        </tr>
-      </thead>
-      <tbody id="deploys-rows"><tr><td colspan="5" class="text-muted text-sm mono">No deploys recorded yet.</td></tr></tbody>
-    </table>
+    <div class="table-scroll">
+      <table class="z">
+        <thead>
+          <tr>
+            <th>when</th><th>commit</th><th>images pulled</th><th>duration</th><th>outcome</th>
+          </tr>
+        </thead>
+        <tbody id="deploys-rows"><tr><td colspan="5" class="text-muted text-sm mono">No deploys recorded yet.</td></tr></tbody>
+      </table>
+    </div>
   </section>
   </div><!-- /.section-body[sec-deploys] -->
 
@@ -1033,12 +1043,14 @@
   </div>
   <div class="section-body" data-for="sec-audit">
   <section class="card overflow-hidden">
-    <table class="z">
-      <thead>
-        <tr><th>when</th><th>action</th><th>ok</th><th>detail</th><th>source</th></tr>
-      </thead>
-      <tbody id="audit-rows"><tr><td colspan="5" class="text-muted text-sm mono">No actions recorded.</td></tr></tbody>
-    </table>
+    <div class="table-scroll">
+      <table class="z">
+        <thead>
+          <tr><th>when</th><th>action</th><th>ok</th><th>detail</th><th>source</th></tr>
+        </thead>
+        <tbody id="audit-rows"><tr><td colspan="5" class="text-muted text-sm mono">No actions recorded.</td></tr></tbody>
+      </table>
+    </div>
   </section>
   </div><!-- /.section-body[sec-audit] -->
 
@@ -1590,9 +1602,9 @@ function drawRequestChart(rps, p95){
   svg.innerHTML = `
     ${grid}
     ${labels}
-    <path d="${rpsArea}" fill="#C9A84C" fill-opacity="0.10"/>
-    <path d="${rpsD}" fill="none" stroke="#C9A84C" stroke-width="1.4" stroke-linejoin="round"/>
-    <path d="${p95D}" fill="none" stroke="#FFA726" stroke-width="1.2" stroke-dasharray="3 3" stroke-linejoin="round"/>
+    <path d="${rpsArea}" fill="#4FC3F7" fill-opacity="0.10"/>
+    <path d="${rpsD}" fill="none" stroke="#4FC3F7" stroke-width="1.4" stroke-linejoin="round"/>
+    <path d="${p95D}" fill="none" stroke="#FF6B6B" stroke-width="1.2" stroke-dasharray="3 3" stroke-linejoin="round"/>
     <line x1="${pad.l}" x2="${W-pad.r}" y1="${H-pad.b}" y2="${H-pad.b}" stroke="#2A2A30"/>
   `;
 }

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -1016,14 +1016,20 @@
   <section class="card p-4 sm:p-5">
     <textarea id="sql-input" rows="5" class="w-full bg-bg mono text-sm p-3 rounded-lg hairline" placeholder="SELECT id, title FROM comics ORDER BY added_at DESC LIMIT 10;"></textarea>
     <div class="flex items-center gap-3 mt-3">
-      <button id="sql-run" class="ibtn">Run (Cmd/Ctrl+Enter)</button>
+      <button id="sql-run" class="tbtn">Run ⌘↵</button>
       <span id="sql-status" class="text-[11px] text-muted mono"></span>
       <div class="flex-1"></div>
-      <select id="sql-history" class="ibtn">
+      <select id="sql-history" class="sel">
         <option value="">History…</option>
       </select>
     </div>
-    <div id="sql-result" class="mt-3 overflow-auto" style="max-height:420px;"></div>
+    <div id="sql-results" class="hidden" style="margin-top:16px">
+      <div class="flex items-baseline justify-between mb-2">
+        <div class="text-[11px] tracking-[.14em] uppercase text-muted">Results</div>
+        <div id="sql-results-meta" class="mono text-[11px] text-muted"></div>
+      </div>
+      <div id="sql-results-body" class="table-scroll"></div>
+    </div>
   </section>
   </div><!-- /.section-body[sec-sql] -->
 
@@ -1143,7 +1149,6 @@
   .sql-table th, .sql-table td{ padding:6px 10px; border-bottom: 1px solid rgba(42,42,48,.5); text-align:left; }
   .sql-table th{ color:var(--muted); text-transform:uppercase; font-size:10px; letter-spacing:.1em; }
   .sql-table td{ color:var(--body); font-family:"JetBrains Mono",monospace; }
-  .sql-error{ color:var(--error); font-family:"JetBrains Mono",monospace; font-size:12px; padding:10px; background:rgba(239,83,80,.08); border-radius:6px; }
 </style>
 
 <script>

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -1147,6 +1147,12 @@
 </style>
 
 <script>
+// AST-86 preview-flag: enables genDataMock in the local preview server.
+// Prod URLs never carry ?preview; this flag is only set by the local preview.
+window.__MONITOR_PREVIEW__ = new URLSearchParams(location.search).has('preview');
+</script>
+
+<script>
 /* =========================================================================
    astral · oci monitor — mock data engine + render
    ---------------------------------------------------------------------------
@@ -1260,11 +1266,33 @@ const shortId = id => id.length > 12 ? id.slice(0,12) : id;
 
 /* ---------- data generator (matches /metrics schema) ---------------- */
 async function genData(range){
+  // AST-86 — preview-server escape hatch. Prod never sets this flag.
+  if (window.__MONITOR_PREVIEW__) return genDataMock(range);
   const resp = await fetch('/metrics?range=' + encodeURIComponent(range), {credentials: 'include'});
   if(!resp.ok){
     throw new Error('metrics fetch failed: ' + resp.status);
   }
   return normalizeMetrics(await resp.json());
+}
+
+// AST-86 — typed-empty data object used when /metrics is unreachable.
+function emptyData(){
+  return {
+    schema_version: '1.0.0',
+    generated_at: new Date().toISOString(),
+    build: '—',
+    region: '—',
+    tenancy_ocid: '—',
+    instance_ocid: '—',
+    cost: null,
+    services: [],
+    requests: { window: '—', series_rps: [], series_p95_ms: [], status_codes: {'2xx':0,'3xx':0,'4xx':0,'5xx':0}, total: 0, slowest: [] },
+    arq: { queue_depth: 0, in_flight: 0, workers: 0, completed_24h: 0, failed_24h: 0, active: [], recent_completed: [], recent_failed: [] },
+    storage: null,
+    backups: { status: '—', recent_runs: [], next_run_in_s: 0, bucket: '—', retention_days: 0 },
+    cert: null,
+    logs: [],
+  };
 }
 
 // Map /metrics schema into the field names the existing renderers expect.
@@ -1661,40 +1689,83 @@ window.refreshService = refreshService;
 async function refreshAll(){
   try {
     STATE.data = await genData(STATE.range);
-    renderAll();
   } catch(e){
     console.error('refreshAll failed', e);
-    toast('metrics unreachable');
+    STATE.data = emptyData();
+    if (!STATE._warnedUnreachable){
+      toast('metrics unreachable');
+      STATE._warnedUnreachable = true;
+    }
   }
+  renderAll();
 }
+
+// AST-86 — six-card skeleton driven by a static list, never by STATE.data.services.
+const SVC_ORDER = ['postgres','redis','fastapi','arq_worker','nginx','certbot'];
+const SVC_IMAGES = {
+  postgres:   'postgres:16-alpine',
+  redis:      'redis:7-alpine',
+  fastapi:    'astral/fastapi:—',
+  arq_worker: 'astral/worker:—',
+  nginx:      'nginx:1.25-alpine',
+  certbot:    'certbot/certbot:latest',
+};
 
 function renderServices(){
   const grid = document.getElementById('svc-grid');
-  const svcs = STATE.data.services;
-  grid.innerHTML = svcs.map(s => {
-    const tone = s.health==='healthy' ? 'ok' : s.health==='starting' ? 'warn' : 'crit';
-    const lbl  = s.health==='healthy' ? 'UP' : s.health==='starting' ? 'STARTING' : 'DOWN';
-    const badge = s.health==='healthy' ? 'badge-ok' : s.health==='starting' ? 'badge-warn' : 'badge-crit';
-    const [imageBase, imageTag] = s.image.split(':');
-    const extra = s.extra || {};
-    let footer = '';
-    if(s.name === 'postgres')  footer = `<span class="mono text-[11px] text-muted">${extra.pg_connections}/${extra.pg_max_connections} conns</span>`;
-    else if(s.name === 'redis') footer = `<span class="mono text-[11px] text-muted">${extra.ops_sec} ops/s · ${extra.keys} keys</span>`;
-    else if(s.name === 'fastapi') footer = `<span class="mono text-[11px] text-muted">${extra.workers}w · ${extra.rps} rps</span>`;
-    else if(s.name === 'arq_worker') footer = `<span class="mono text-[11px] text-muted">${extra.jobs_active}/${extra.max} jobs</span>`;
-    else if(s.name === 'nginx') footer = `<span class="mono text-[11px] text-muted">${extra.active_connections} conns · ${extra.reqs_total.toLocaleString()} req</span>`;
-    else if(s.name === 'certbot') footer = `<span class="mono text-[11px] text-muted">next check ${extra.next_check_in}</span>`;
+  const entries = STATE.data.services || [];
+  grid.innerHTML = SVC_ORDER.map(name => {
+    const s = entries.find(e => e && e.name === name);
+    const hasData = !!s;
+    const hasSpark = hasData && Array.isArray(s.spark) && s.spark.length > 0;
+
+    let badge, tone, lbl;
+    if (!hasData) {
+      badge = 'badge-warn'; tone = 'warn'; lbl = 'NO DATA';
+    } else if (s.health === 'healthy') {
+      badge = 'badge-ok'; tone = 'ok'; lbl = 'UP';
+    } else if (s.health === 'starting') {
+      badge = 'badge-warn'; tone = 'warn'; lbl = 'STARTING';
+    } else {
+      badge = 'badge-crit'; tone = 'crit'; lbl = 'DOWN';
+    }
+
+    const imageStr = hasData ? (s.image || SVC_IMAGES[name]) : SVC_IMAGES[name];
+    const [imageBase, imageTag] = imageStr.split(':');
+
+    const uptime = hasData ? fmtUptime(s.uptime_s) : '—';
+    const cpuMem = hasData
+      ? `${Number(s.cpu || 0).toFixed(1)}% · ${s.mem || 0}MB`
+      : '— · —';
+
+    const sparkMarkup = hasSpark
+      ? sparkSvg(s.spark, {tone: tone === 'ok' ? '' : tone})
+      : `<svg class="spark" viewBox="0 0 200 30" preserveAspectRatio="none" style="width:100%;height:30px"><text class="spark-empty" x="4" y="19">no data</text></svg>`;
+
+    let footer = '<span class="mono text-[11px] text-muted">metrics unreachable</span>';
+    if (hasData) {
+      const extra = s.extra || {};
+      if (name === 'postgres')        footer = `<span class="mono text-[11px] text-muted">${extra.pg_connections ?? '—'}/${extra.pg_max_connections ?? '—'} conns</span>`;
+      else if (name === 'redis')      footer = `<span class="mono text-[11px] text-muted">${extra.ops_sec ?? '—'} ops/s · ${extra.keys ?? '—'} keys</span>`;
+      else if (name === 'fastapi')    footer = `<span class="mono text-[11px] text-muted">${extra.workers ?? '—'}w · ${extra.rps ?? '—'} rps</span>`;
+      else if (name === 'arq_worker') footer = `<span class="mono text-[11px] text-muted">${extra.jobs_active ?? '—'}/${extra.max ?? '—'} jobs</span>`;
+      else if (name === 'nginx')      footer = `<span class="mono text-[11px] text-muted">${extra.active_connections ?? '—'} conns · ${(extra.reqs_total ?? 0).toLocaleString()} req</span>`;
+      else if (name === 'certbot')    footer = `<span class="mono text-[11px] text-muted">next check ${extra.next_check_in ?? '—'}</span>`;
+    }
+
+    const bodyClass = hasData ? '' : ' svc-dim';
+    const containerId = hasData ? (s.container_id || '') : '';
 
     return `
-    <div class="card svc-card p-4" data-service-card="${s.name}">
+    <div class="card svc-card p-4${bodyClass}" data-service-card="${name}">
       <div class="flex items-start gap-3 svc-card-header">
-        <div class="elevated w-8 h-8 flex items-center justify-center text-muted" style="border-radius:8px">${svcIcon(s.name)}</div>
+        <div class="elevated w-8 h-8 flex items-center justify-center text-muted" style="border-radius:8px">${svcIcon(name)}</div>
         <div class="flex-1 min-w-0">
           <div class="flex items-center gap-2">
-            <span class="text-white font-semibold tracking-tight truncate">${s.name}</span>
+            <span class="text-white font-semibold tracking-tight truncate">${name}</span>
             <span class="badge ${badge}"><span class="dot ${tone}"></span>${lbl}</span>
             <span class="flex-1"></span>
-            <button class="ibtn svc-refresh" style="width:24px;height:24px;" title="refresh ${s.name}" onclick="event.stopPropagation(); this.classList.add('spin'); setTimeout(()=>this.classList.remove('spin'),700); refreshService('${s.name}');">
+            <button class="ibtn svc-refresh" style="width:24px;height:24px;" title="refresh ${name}" onclick="event.stopPropagation(); this.classList.add('spin'); setTimeout(()=>this.classList.remove('spin'),700); refreshService('${name}');">
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
             </button>
           </div>
@@ -1707,18 +1778,18 @@ function renderServices(){
       <div class="mt-3 flex items-baseline justify-between">
         <div>
           <div class="text-[11px] tracking-[.14em] uppercase text-muted">uptime</div>
-          <div class="mono text-sm text-white">${fmtUptime(s.uptime_s)}</div>
+          <div class="mono text-sm text-white">${uptime}</div>
         </div>
         <div class="text-right">
           <div class="text-[11px] tracking-[.14em] uppercase text-muted">cpu · mem</div>
-          <div class="mono text-sm text-white">${s.cpu.toFixed(1)}% · ${s.mem}MB</div>
+          <div class="mono text-sm text-white">${cpuMem}</div>
         </div>
       </div>
       <div class="mt-2">
-        ${sparkSvg(s.spark,{tone:tone==='ok'?'':tone})}
+        ${sparkMarkup}
       </div>
       <div class="mt-1 flex justify-between items-center">
-        <span class="copy" data-copy="${s.container_id || ''}">${(s.container_id || '').slice(0,12)} <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
+        <span class="copy" data-copy="${containerId}">${containerId.slice(0,12) || '—'} <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
         ${footer}
       </div>
     </div>`;

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -1813,7 +1813,7 @@ function renderServices(){
             ${sparkMarkup}
           </div>
           <div class="mt-1 flex justify-between items-center">
-            ${containerId ? `<span class="copy" data-copy="${containerId}">${containerId.slice(0,12)} <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>` : '<span class="text-muted text-[11px] mono">—</span>'}
+            <span class="copy" data-copy="${containerId}" title="${containerId ? 'copy container id' : 'no container id available'}">${containerId.slice(0,12)}<svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="margin-left:6px"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
             ${footer}
           </div>
         </div>

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -1813,7 +1813,7 @@ function renderServices(){
             ${sparkMarkup}
           </div>
           <div class="mt-1 flex justify-between items-center">
-            <span class="copy" data-copy="${containerId}">${containerId.slice(0,12) || '—'} <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
+            ${containerId ? `<span class="copy" data-copy="${containerId}">${containerId.slice(0,12)} <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>` : '<span class="text-muted text-[11px] mono">—</span>'}
             ${footer}
           </div>
         </div>

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -335,6 +335,88 @@
     .log{ grid-template-columns: 64px 64px 1fr; gap: 8px; font-size:11px; }
     .chart-wrap{ min-height:140px; }
   }
+
+  /* ─── AST-78 polish-pass helpers ─────────────────────────────── */
+
+  /* AST-87 — solid-accent primary button */
+  .tbtn{
+    background: var(--gold); color: #0a0a0a; border: 1px solid var(--gold);
+    padding: 6px 14px; border-radius: 8px;
+    font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+    font-size: 12px; letter-spacing: .04em;
+    transition: transform .08s ease, opacity .12s;
+    cursor: pointer;
+  }
+  .tbtn:hover{ opacity: .9; }
+  .tbtn:active{ transform: scale(.97); }
+
+  /* AST-87 — styled native <select> */
+  .sel{
+    background: var(--surface); color: var(--white);
+    border: 1px solid var(--border);
+    padding: 6px 10px; border-radius: 8px;
+    font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+    font-size: 12px; cursor: pointer;
+  }
+
+  /* AST-88 — red-tinted SQL error box (supersedes the older .sql-error below) */
+  .sql-error{
+    background: rgba(255,107,107,.08);
+    border: 1px solid rgba(255,107,107,.4);
+    color: #FF9A9A;
+    padding: 10px 12px; border-radius: 8px;
+    font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+    white-space: pre-wrap;
+  }
+
+  /* AST-91 — single scroll wrapper for every dashboard table */
+  .table-scroll{ max-height: 360px; overflow: auto; border-radius: 8px; }
+  .table-scroll thead th{
+    position: sticky; top: 0; background: var(--surface); z-index: 1;
+  }
+
+  /* AST-83 — collapsible section heads */
+  .section-head{ cursor: pointer; user-select: none; }
+  .section-head .chev{ transition: transform .18s ease; flex-shrink: 0; }
+  .section-head.collapsed .chev{ transform: rotate(-90deg); }
+  .section-body.collapsed{ display: none; }
+
+  /* AST-78-ext2 — 3D flip wrapper for service cards */
+  .svc-flip{ perspective: 1200px; }
+  .svc-flip-inner{
+    position: relative; transition: transform .5s;
+    transform-style: preserve-3d;
+  }
+  .svc-flip.flipped .svc-flip-inner{ transform: rotateY(180deg); }
+  .svc-face{
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+  }
+  .svc-face.back{
+    position: absolute; inset: 0; transform: rotateY(180deg);
+    background: var(--surface);
+    border-radius: 8px; padding: 14px;
+    display: flex; flex-direction: column; gap: 8px;
+  }
+  .svc-face.back .term-body{
+    flex: 1;
+    background: #0a0a0b; border: 1px solid var(--border); border-radius: 6px;
+    padding: 10px; font-family: "JetBrains Mono", monospace; font-size: 12px;
+    color: var(--body);
+    overflow: auto;
+  }
+  .svc-face.back .term-close{
+    position: absolute; top: 8px; right: 8px;
+    width: 22px; height: 22px;
+    display: inline-flex; align-items: center; justify-content: center;
+    color: var(--muted); background: transparent; border: 0; cursor: pointer;
+    border-radius: 4px;
+  }
+  .svc-face.back .term-close:hover{ color: var(--white); background: var(--elevated); }
+
+  /* AST-86 — skeleton / no-data */
+  .svc-dim{ opacity: .5; filter: grayscale(.3); }
+  .spark-empty{ font-size: 10px; color: var(--muted); letter-spacing: .12em; }
 </style>
 </head>
 

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -717,12 +717,6 @@
             </div>
           </div>
         </div>
-        <div class="flex gap-2 text-[11px] text-muted mono">
-          <span class="badge badge-ok">2xx <span id="sc-2" class="mono text-body ml-1">18,421</span></span>
-          <span class="badge badge-muted">3xx <span id="sc-3" class="mono text-body ml-1">320</span></span>
-          <span class="badge badge-warn">4xx <span id="sc-4" class="mono text-body ml-1">87</span></span>
-          <span class="badge badge-crit">5xx <span id="sc-5" class="mono text-body ml-1">3</span></span>
-        </div>
       </div>
 
       <div class="chart-wrap mt-4">
@@ -1207,6 +1201,9 @@ STATE.collapsed = (() => {
     return Object.assign({}, COLLAPSE_DEFAULTS);
   }
 })();
+
+// AST-84 — codes present in the Set are DIMMED in the Status Codes panel.
+STATE.statusFilter = new Set();
 
 function applyCollapsed(id){
   const head = document.getElementById(id);
@@ -1745,10 +1742,6 @@ function renderRequests(){
     document.getElementById('p95-now').innerHTML = `0<span class="text-muted text-sm ml-0.5">ms</span>`;
     document.getElementById('req-total').textContent = '0';
     document.getElementById('req-window').textContent = RANGE_LABELS[STATE.range];
-    document.getElementById('sc-2').textContent = '0';
-    document.getElementById('sc-3').textContent = '0';
-    document.getElementById('sc-4').textContent = '0';
-    document.getElementById('sc-5').textContent = '0';
     document.getElementById('statusBars').innerHTML = '';
     document.getElementById('slowest').innerHTML =
       '<tr><td colspan="3" class="text-muted mono text-[12px] py-3 text-center">no requests to rank</td></tr>';
@@ -1760,17 +1753,14 @@ function renderRequests(){
   document.getElementById('p95-now').innerHTML = `${Math.round(r.series_p95_ms.at(-1))}<span class="text-muted text-sm ml-0.5">ms</span>`;
   document.getElementById('req-total').textContent = r.total.toLocaleString();
   document.getElementById('req-window').textContent = RANGE_LABELS[STATE.range];
-  document.getElementById('sc-2').textContent = r.status_codes['2xx'].toLocaleString();
-  document.getElementById('sc-3').textContent = r.status_codes['3xx'].toLocaleString();
-  document.getElementById('sc-4').textContent = r.status_codes['4xx'].toLocaleString();
-  document.getElementById('sc-5').textContent = r.status_codes['5xx'].toLocaleString();
 
-  // status bars (right panel)
+  // AST-84 — status bars (right panel) become click-to-dim toggles.
   const total = Object.values(r.status_codes).reduce((a,b)=>a+b,0);
   const colors = { '2xx':'var(--success)', '3xx':'var(--muted)', '4xx':'var(--warning)', '5xx':'var(--error)' };
   document.getElementById('statusBars').innerHTML = Object.entries(r.status_codes).map(([k,v])=>{
     const pct = (v/total*100).toFixed(v>total*0.1?0:2);
-    return `<div>
+    const dim = STATE.statusFilter.has(k) ? ' svc-dim' : '';
+    return `<div class="sc-row${dim}" data-code="${k}" style="cursor:pointer">
       <div class="flex justify-between text-[12px] mono">
         <span style="color:${colors[k]}">${k}</span>
         <span class="text-body">${v.toLocaleString()} <span class="text-muted">· ${pct}%</span></span>
@@ -1778,6 +1768,14 @@ function renderRequests(){
       <div class="bar-track mt-1"><span style="width:${Math.max(0.5,(v/total*100))}%; background:${colors[k]}"></span></div>
     </div>`;
   }).join('');
+  document.querySelectorAll('#statusBars .sc-row').forEach(row => {
+    row.addEventListener('click', () => {
+      const code = row.dataset.code;
+      if (STATE.statusFilter.has(code)) STATE.statusFilter.delete(code);
+      else STATE.statusFilter.add(code);
+      row.classList.toggle('svc-dim', STATE.statusFilter.has(code));
+    });
+  });
 
   // slowest table
   document.getElementById('slowest').innerHTML = r.slowest.map(e=>`

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -1762,43 +1762,80 @@ function renderServices(){
     const containerId = hasData ? (s.container_id || '') : '';
 
     return `
-    <div class="card svc-card p-4${bodyClass}" data-service-card="${name}">
-      <div class="flex items-start gap-3 svc-card-header">
-        <div class="elevated w-8 h-8 flex items-center justify-center text-muted" style="border-radius:8px">${svcIcon(name)}</div>
-        <div class="flex-1 min-w-0">
-          <div class="flex items-center gap-2">
-            <span class="text-white font-semibold tracking-tight truncate">${name}</span>
-            <span class="badge ${badge}"><span class="dot ${tone}"></span>${lbl}</span>
-            <span class="flex-1"></span>
-            <button class="ibtn svc-refresh" style="width:24px;height:24px;" title="refresh ${name}" onclick="event.stopPropagation(); this.classList.add('spin'); setTimeout(()=>this.classList.remove('spin'),700); refreshService('${name}');">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
-            </button>
+    <div class="svc-flip" data-service-card="${name}">
+      <div class="svc-flip-inner">
+        <div class="svc-face front card svc-card p-4${bodyClass}">
+          <div class="flex items-start gap-3 svc-card-header">
+            <div class="elevated w-8 h-8 flex items-center justify-center text-muted" style="border-radius:8px">${svcIcon(name)}</div>
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center gap-2">
+                <span class="text-white font-semibold tracking-tight truncate">${name}</span>
+                <span class="badge ${badge}"><span class="dot ${tone}"></span>${lbl}</span>
+                <span class="flex-1"></span>
+                <button class="ibtn svc-terminal" style="width:24px;height:24px;" title="open shell in ${name}" data-service="${name}">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+                </button>
+              </div>
+              <div class="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted mono truncate">
+                <span class="truncate">${imageBase}</span>
+                <span style="color:var(--gold)">:${imageTag||'latest'}</span>
+                <button class="ibtn svc-refresh-mini" style="width:16px;height:16px;margin-left:4px;" title="refresh ${name}" onclick="event.stopPropagation(); this.classList.add('spin'); setTimeout(()=>this.classList.remove('spin'),700); refreshService('${name}');">
+                  <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
+                </button>
+              </div>
+            </div>
           </div>
-          <div class="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted mono truncate">
-            <span class="truncate">${imageBase}</span>
-            <span style="color:var(--gold)">:${imageTag||'latest'}</span>
+          <div class="mt-3 flex items-baseline justify-between">
+            <div>
+              <div class="text-[11px] tracking-[.14em] uppercase text-muted">uptime</div>
+              <div class="mono text-sm text-white">${uptime}</div>
+            </div>
+            <div class="text-right">
+              <div class="text-[11px] tracking-[.14em] uppercase text-muted">cpu · mem</div>
+              <div class="mono text-sm text-white">${cpuMem}</div>
+            </div>
+          </div>
+          <div class="mt-2">
+            ${sparkMarkup}
+          </div>
+          <div class="mt-1 flex justify-between items-center">
+            <span class="copy" data-copy="${containerId}">${containerId.slice(0,12) || '—'} <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
+            ${footer}
           </div>
         </div>
-      </div>
-      <div class="mt-3 flex items-baseline justify-between">
-        <div>
-          <div class="text-[11px] tracking-[.14em] uppercase text-muted">uptime</div>
-          <div class="mono text-sm text-white">${uptime}</div>
+        <div class="svc-face back">
+          <button class="term-close" title="close terminal" data-close-term="${name}">✕</button>
+          <div class="text-[11px] tracking-[.14em] uppercase text-muted">Shell · ${name}</div>
+          <div class="term-body"><span style="color:var(--gold)">$</span> <span class="mono">_</span>
+<div class="mt-2 text-muted text-[11px]">Terminal UI is a stub — real exec channel lands in AST-92.</div></div>
         </div>
-        <div class="text-right">
-          <div class="text-[11px] tracking-[.14em] uppercase text-muted">cpu · mem</div>
-          <div class="mono text-sm text-white">${cpuMem}</div>
-        </div>
-      </div>
-      <div class="mt-2">
-        ${sparkMarkup}
-      </div>
-      <div class="mt-1 flex justify-between items-center">
-        <span class="copy" data-copy="${containerId}">${containerId.slice(0,12) || '—'} <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
-        ${footer}
       </div>
     </div>`;
   }).join('');
+
+  // AST-78-ext2 — terminal flip wiring (re-bound on every render)
+  document.querySelectorAll('.svc-terminal').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const name = btn.dataset.service;
+      const wrap = btn.closest('.svc-flip');
+      if (!wrap) return;
+      wrap.classList.add('flipped');
+      STATE.flippedCards = STATE.flippedCards || new Set();
+      STATE.flippedCards.add(name);
+      toast('coming soon — AST-92');
+    });
+  });
+  document.querySelectorAll('.term-close').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const name = btn.dataset.closeTerm;
+      const wrap = btn.closest('.svc-flip');
+      if (!wrap) return;
+      wrap.classList.remove('flipped');
+      if (STATE.flippedCards) STATE.flippedCards.delete(name);
+    });
+  });
 }
 
 function renderRequests(){

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -1082,8 +1082,6 @@
       <span>data as of <span id="asof">—</span></span>
       <span>·</span>
       <span><kbd>r</kbd> refresh · <kbd>1</kbd>–<kbd>4</kbd> range · <kbd>/</kbd> search</span>
-      <span>·</span>
-      <a id="ctrl-logout" href="#" class="text-muted hover:text-white" title="forget control token">🔑 clear token</a>
     </div>
   </footer>
 
@@ -1124,20 +1122,6 @@
   </div>
 </div>
 
-
-<!-- ─── TOKEN PROMPT ───────────────────────────────────────────────── -->
-<div id="token-modal" class="endpoint-modal" style="display:none;">
-  <div class="endpoint-dialog card p-5" style="max-width:480px;">
-    <div class="text-[11px] tracking-[.14em] uppercase text-muted">Auth required</div>
-    <div class="text-white font-semibold mt-1 mb-3">Monitor control token</div>
-    <div class="text-muted text-sm mb-3">This action requires the control token (set in <code>MONITOR_CONTROL_TOKEN</code>). It's stored in your browser's localStorage — clear it by running <code>localStorage.removeItem('monitor_control_token')</code> in the console.</div>
-    <input id="token-input" type="password" class="search w-full" placeholder="paste token…">
-    <div class="flex gap-2 justify-end mt-3">
-      <button id="token-cancel" class="ibtn">Cancel</button>
-      <button id="token-save"   class="ibtn">Save</button>
-    </div>
-  </div>
-</div>
 
 <style>
   .endpoint-modal{ position:fixed; inset:0; background:rgba(0,0,0,.6); z-index:100; display:flex; align-items:center; justify-content:center; padding:20px; }

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -300,23 +300,28 @@
     background: var(--gold); color: #0a0a0a; border: 1px solid var(--gold);
     padding: 6px 14px; border-radius: 8px;
     font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
-    font-size: 12px; letter-spacing: .04em;
+    font-size: 12px; font-weight: 600; letter-spacing: .04em;
     transition: transform .08s ease, opacity .12s;
     cursor: pointer;
   }
   .tbtn:hover{ opacity: .9; }
   .tbtn:active{ transform: scale(.97); }
+  .tbtn:focus-visible{ outline: none; box-shadow: 0 0 0 2px var(--gold-tint); }
 
   /* AST-87 — styled native <select> */
   .sel{
+    appearance: none; -webkit-appearance: none;
     background: var(--surface); color: var(--white);
     border: 1px solid var(--border);
-    padding: 6px 10px; border-radius: 8px;
+    padding: 6px 26px 6px 10px; border-radius: 8px;
     font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
     font-size: 12px; cursor: pointer;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%236B6B7A' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><path d='m6 9 6 6 6-6'/></svg>");
+    background-repeat: no-repeat; background-position: right 8px center;
   }
+  .sel:focus-visible{ outline: none; box-shadow: inset 0 0 0 1px var(--gold); }
 
-  /* AST-88 — red-tinted SQL error box (supersedes the older .sql-error below) */
+  /* AST-88 — red-tinted SQL error box (replaces older rule; Task 7 deleted it) */
   .sql-error{
     background: rgba(255,107,107,.08);
     border: 1px solid rgba(255,107,107,.4);
@@ -370,6 +375,7 @@
     border-radius: 4px;
   }
   .svc-face.back .term-close:hover{ color: var(--white); background: var(--elevated); }
+  .svc-face.back .term-close:focus-visible{ outline: none; box-shadow: inset 0 0 0 1px var(--gold); }
 
   /* AST-86 — skeleton / no-data */
   .svc-dim{ opacity: .5; filter: grayscale(.3); }
@@ -2334,6 +2340,6 @@ applyAllCollapsed();
      FastAPI app.mount("/static", ...) inside astral_monitor. An absolute
      "/static/..." path collides with nginx's `location /static/` block
      (aliased to the media volume) and returns 404. -->
-<script src="static/controls.js?v=3"></script>
+<script src="static/controls.js?v=4"></script>
 </body>
 </html>

--- a/backend/monitor/static/index.html
+++ b/backend/monitor/static/index.html
@@ -123,14 +123,6 @@
   .seg button:hover{ color:var(--body); }
   .seg button.active{ background: var(--surface); color: var(--white); box-shadow: inset 0 0 0 0.5px var(--border); }
 
-  /* Env pill (PROD) — uses gold tint */
-  .env-pill{
-    display:inline-flex; align-items:center; gap:6px;
-    padding: 3px 9px; border-radius:999px;
-    background: var(--gold-tint); color: var(--gold);
-    font: 600 11px/1 "Inter",sans-serif; letter-spacing:.1em;
-  }
-
   /* Kbd */
   kbd{
     display:inline-block; padding: 1px 6px; border-radius:4px;
@@ -188,12 +180,6 @@
   /* Refresh spin */
   @keyframes spin { to { transform: rotate(360deg); } }
   .spin { animation: spin 700ms linear; }
-
-  /* Toggle */
-  .tgl{ width:30px; height:18px; background:var(--elevated); border-radius:999px; position:relative; cursor:pointer; box-shadow: inset 0 0 0 0.5px var(--border); transition: background 200ms ease; }
-  .tgl::after{ content:""; position:absolute; top:2px; left:2px; width:14px; height:14px; border-radius:50%; background:var(--muted); transition: all 200ms cubic-bezier(0.22,1,0.36,1); }
-  .tgl.on{ background: var(--gold-tint); }
-  .tgl.on::after{ left:14px; background: var(--gold); }
 
   /* Chart containers */
   .chart-wrap{ width:100%; aspect-ratio: 16 / 6; min-height:160px; }
@@ -275,35 +261,6 @@
   .burn-track > span{ flex:1; background: rgba(107,107,122,.2); border-radius:2px; }
   .burn-track > span.used{ background: var(--gold); }
   .burn-track > span.over{ background: var(--error); }
-
-  /* Incidents timeline strip */
-  .timeline{
-    position:relative; height:38px;
-    background: repeating-linear-gradient(to right,
-      transparent 0, transparent calc(100%/24 - 1px),
-      rgba(42,42,48,.6) calc(100%/24 - 1px), rgba(42,42,48,.6) calc(100%/24));
-    border-radius:6px; box-shadow: inset 0 0 0 0.5px var(--border);
-    overflow:hidden;
-  }
-  .timeline .ev{
-    position:absolute; top:6px; height:26px; border-radius:3px; cursor:pointer;
-    transition: transform 180ms cubic-bezier(0.22,1,0.36,1), box-shadow 180ms ease;
-    display:flex; align-items:center; padding:0 6px; overflow:hidden;
-    font: 500 10px/1 "JetBrains Mono",monospace; color:rgba(10,10,11,.85); white-space:nowrap;
-  }
-  .timeline .ev:hover{ transform: scaleY(1.08); box-shadow: 0 0 0 1px rgba(255,255,255,.15); z-index:2; }
-  .timeline .ev.warn{ background: rgba(255,167,38,.75); }
-  .timeline .ev.ok{   background: rgba(76,175,80,.7); }
-  .timeline .ev.crit{ background: rgba(239,83,80,.8); }
-  .timeline .ev.info{ background: rgba(201,168,76,.7); }
-  .timeline .hr-label{
-    position:absolute; bottom:2px; font: 400 9px/1 "JetBrains Mono",monospace;
-    color: var(--muted); transform: translateX(-50%); pointer-events:none;
-  }
-  .timeline .now-line{
-    position:absolute; top:0; bottom:0; width:1px; background: var(--gold);
-    box-shadow: 0 0 6px rgba(201,168,76,.6);
-  }
 
   /* Uptime probe grid */
   .uptime-grid{ display:grid; grid-template-columns: repeat(60, 1fr); gap:2px; }
@@ -579,8 +536,6 @@
       <span class="text-muted mono text-[11px]">· oci monitor</span>
     </div>
 
-    <span class="env-pill"><span class="dot ok"></span>PROD</span>
-
     <!-- Live indicator -->
     <span class="hidden md:inline-flex items-center gap-1.5 mono text-[11px] text-muted">
       <span class="dot ok live-dot"></span>
@@ -610,11 +565,6 @@
       <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
     </button>
 
-    <!-- Auto-refresh toggle -->
-    <div class="flex items-center gap-2">
-      <span class="text-[11px] text-muted hidden sm:inline">auto</span>
-      <span id="auto" class="tgl on" role="switch" aria-checked="true"></span>
-    </div>
   </div>
 </header>
 
@@ -646,7 +596,7 @@
         <div class="hr mt-4 pt-4">
           <div class="kv">
             <span class="k">budget alert</span>
-            <span class="v flex items-center gap-1.5"><span class="dot ok"></span>armed</span>
+            <span class="v">armed</span>
           </div>
           <div class="kv">
             <span class="k">billing mode</span>
@@ -722,24 +672,8 @@
   <div class="section-head" id="sec-services">
     <span class="crumb">astral / oci / <span class="cur">service health</span></span>
     <span class="rule"></span>
-    <span class="mono text-[11px] text-muted">docker compose ps · 6 services · <span id="inc-count">3</span> incidents in 24h</span>
+    <span class="mono text-[11px] text-muted">docker compose ps · 6 services</span>
   </div>
-
-  <!-- Incidents timeline (GCP Ops) -->
-  <section class="card p-3 sm:p-4 mb-3">
-    <div class="flex items-center justify-between mb-2">
-      <div class="text-[11px] tracking-[.14em] uppercase text-muted">Incidents · last 24h</div>
-      <div class="flex items-center gap-2 text-[11px] text-muted mono">
-        <span class="flex items-center gap-1"><span class="dot" style="background:var(--warning); width:6px; height:6px;"></span>warn</span>
-        <span class="flex items-center gap-1"><span class="dot crit" style="width:6px; height:6px; box-shadow:none;"></span>crit</span>
-        <span class="flex items-center gap-1"><span class="dot" style="background:var(--gold); width:6px; height:6px;"></span>info</span>
-      </div>
-    </div>
-    <div class="timeline" id="timeline">
-      <div class="now-line" style="right:0"></div>
-    </div>
-    <div class="relative mt-1" style="height:12px;" id="timeline-labels"></div>
-  </section>
 
   <section class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
     <!-- cards injected below -->
@@ -911,7 +845,7 @@
 
       <div class="hr mt-4 pt-4">
         <table class="z">
-          <thead><tr><th>started</th><th>took</th><th>size</th><th>status</th></tr></thead>
+          <thead><tr><th>started</th><th>took</th><th>size</th></tr></thead>
           <tbody id="bk-rows"></tbody>
         </table>
       </div>
@@ -1192,11 +1126,9 @@ const RANGE_LABELS = { '1h':'last 1h', '6h':'last 6h','24h':'last 24h','7d':'las
 
 const STATE = {
   range: '6h',
-  auto: true,
   logFilter: '',
   svcFilter: 'all',
   data: null,
-  autoTimer: null,
 };
 // Expose STATE so the controls.js companion can read the current
 // range / service filter without duplicating state.
@@ -1425,11 +1357,11 @@ function genDataMock(range){
       last_pg_dump:'2026-04-20T03:00:12Z', last_size_bytes:2.05e9, status:'ok', next_run_in_s: 45588,
       bucket:'astral-backups', retention_days:30,
       recent_runs:[
-        { started:'2026-04-20T03:00:00Z', duration_s: 8.4,  size_bytes: 2.05e9, status:'ok' },
-        { started:'2026-04-19T03:00:00Z', duration_s: 7.9,  size_bytes: 1.98e9, status:'ok' },
-        { started:'2026-04-18T03:00:00Z', duration_s: 8.1,  size_bytes: 1.96e9, status:'ok' },
-        { started:'2026-04-17T03:00:00Z', duration_s: 7.7,  size_bytes: 1.93e9, status:'ok' },
-        { started:'2026-04-16T03:00:00Z', duration_s: 9.2,  size_bytes: 1.90e9, status:'ok' },
+        { started:'2026-04-20T03:00:00Z', duration_s: 8.4,  size_bytes: 2.05e9 },
+        { started:'2026-04-19T03:00:00Z', duration_s: 7.9,  size_bytes: 1.98e9 },
+        { started:'2026-04-18T03:00:00Z', duration_s: 8.1,  size_bytes: 1.96e9 },
+        { started:'2026-04-17T03:00:00Z', duration_s: 7.7,  size_bytes: 1.93e9 },
+        { started:'2026-04-16T03:00:00Z', duration_s: 9.2,  size_bytes: 1.90e9 },
       ]
     },
     cert:{ domain:'astral-reader.duckdns.org', issuer:"Let's Encrypt R11",
@@ -1447,16 +1379,6 @@ function genDataMock(range){
         burn: { '1h': +(rnd()*0.6).toFixed(2), '6h': +(rnd()*0.8).toFixed(2), '24h': +(rnd()*1.2).toFixed(2) },
       }
     },
-    incidents: (function(){
-      // 24h timeline (0 = 24h ago, 1 = now); one warn spike + 2 info events
-      return [
-        { id:'inc-0412', startPct: 0.08, endPct: 0.13, sev:'info', title:'certbot restart', svc:'certbot' },
-        { id:'inc-0318', startPct: 0.32, endPct: 0.36, sev:'warn', title:'p95 spike 812ms',  svc:'fastapi' },
-        { id:'inc-0291', startPct: 0.58, endPct: 0.62, sev:'info', title:'pg checkpoint slow', svc:'postgres' },
-        { id:'inc-0144', startPct: 0.78, endPct: 0.81, sev:'warn', title:'ao3 scrape 429',   svc:'arq_worker' },
-        { id:'inc-0098', startPct: 0.93, endPct: 0.96, sev:'info', title:'backup complete',   svc:'postgres' },
-      ];
-    })(),
     uptime_checks: [
       {
         name: 'api.health',
@@ -1836,10 +1758,8 @@ function renderBackups(){
       <td class="mono text-body">${r.started.slice(0,10)} <span class="text-muted">${d.toUTCString().slice(17,25)}</span></td>
       <td class="mono">${r.duration_s}s</td>
       <td class="mono">${fmtBytes(r.size_bytes)}</td>
-      <td><span class="badge ${r.status==='ok'?'badge-ok':'badge-warn'}"><span class="dot ${r.status==='ok'?'ok':'warn'}"></span>${r.status.toUpperCase()}</span></td>
     </tr>`;
   }).join('');
-  // countdown
   const s = b.next_run_in_s;
   const h = Math.floor(s/3600), m = Math.floor((s%3600)/60);
   document.getElementById('bk-next').textContent = `${h}h ${pad2(m)}m`;
@@ -2155,16 +2075,8 @@ function doRefresh(){
 }
 document.getElementById('refresh').addEventListener('click', doRefresh);
 
-// auto toggle
-function setAuto(on){
-  STATE.auto = on;
-  const el = document.getElementById('auto');
-  el.classList.toggle('on', on);
-  el.setAttribute('aria-checked', on);
-  if(STATE.autoTimer){ clearInterval(STATE.autoTimer); STATE.autoTimer=null; }
-  if(on){ STATE.autoTimer = setInterval(()=> { refreshAll(); }, 30_000); }
-}
-document.getElementById('auto').addEventListener('click', ()=> setAuto(!STATE.auto));
+// AST-81 — auto-refresh ticks unconditionally every 30s (no user toggle).
+setInterval(() => { refreshAll(); }, 30_000);
 
 // log filter
 document.getElementById('log-filter').addEventListener('input', e=>{
@@ -2201,7 +2113,6 @@ document.addEventListener('keydown', e=>{
    BOOT
    ========================================================================= */
 refreshAll();
-setAuto(true);
 </script>
 
 <!-- control plane UI — decorated after the main renderer settles.

--- a/backend/monitor/tests/test_main.py
+++ b/backend/monitor/tests/test_main.py
@@ -23,3 +23,36 @@ async def test_root_serves_index_html():
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("text/html")
     assert b"<title>astral" in resp.content.lower()
+
+
+@pytest.mark.asyncio
+async def test_index_html_ast78_polish_markers():
+    """Protects the AST-78 polish surface from regressions."""
+    from monitor.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/")
+    assert resp.status_code == 200
+    html = resp.text
+
+    required = [
+        "section-body",          # AST-83 collapsible wrappers
+        "tbtn",                  # AST-87 primary-button class
+        "sql-results",           # AST-88 results wrapper
+        "svc-flip",              # AST-78-ext2 flip wrapper
+        "table-scroll",          # AST-91 table wrapper
+        "svc-terminal",          # AST-78-ext2 terminal button
+        "__MONITOR_PREVIEW__",   # AST-86 preview-flag setter
+    ]
+    for needle in required:
+        assert needle in html, f"missing marker: {needle}"
+
+    banned = [
+        'class="env-pill"',            # AST-79
+        'id="auto"',                   # AST-81 toggle UI
+        "Incidents · last 24h",        # AST-89
+        'id="sql-result"',             # AST-88 — old container id
+    ]
+    for needle in banned:
+        assert needle not in html, f"regression: {needle!r} should have been removed"

--- a/docs/superpowers/plans/2026-04-22-monitor-dashboard-polish-plan.md
+++ b/docs/superpowers/plans/2026-04-22-monitor-dashboard-polish-plan.md
@@ -1,0 +1,1709 @@
+# Monitor Dashboard UI/UX Polish — AST-78 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a bundled front-end polish pass for the OCI monitor dashboard that closes AST-79 through AST-91 (12 Linear subissues) plus two scope extensions — relocating per-card refresh and adding a terminal-flip stub for AST-92.
+
+**Architecture:** Single-PR frontend change touching only `backend/monitor/static/index.html` and `backend/monitor/static/controls.js`. Nine commits in sequence, each independently buildable and previewable via the existing `monitor-preview` launch config. One Python smoke test protects the markers in the final commit.
+
+**Tech Stack:** Vanilla HTML/CSS/JS (no build step) • Tailwind utility classes via CDN • FastAPI backend (unchanged) • `python3 -m http.server`-style preview server at `scratchpad/monitor-preview-server.py` • pytest + httpx ASGITransport for the smoke test.
+
+---
+
+## Source-Code Orientation
+
+Read this once before starting. It keeps every task short.
+
+`backend/monitor/static/index.html` (2133 lines) owns ALL core dashboard logic. Inline `<style>` block runs L14–L338. Inline `<script>` block runs L1091–L2123 and owns `STATE`, `genData`, `genDataMock`, `drawRequestChart`, every `render*` function, `refreshAll`, `setAuto`, and the boot call. The spec occasionally refers to "controls.js" for renderers — that is wrong; all renderers are in `index.html`.
+
+`backend/monitor/static/controls.js` (898 lines) is an IIFE module. Owns the SQL console (`runSQL`, `renderSQLTable`), kill-switch wiring, service-card control buttons, deploy/audit tables. Touch only the SQL-console section for AST-87/AST-88.
+
+**Key line-number cheat sheet** (line numbers apply to the HEAD commit — they WILL drift as tasks land; prefer searching for the anchor string with your editor):
+
+| Anchor | File | Approx line | Purpose |
+|---|---|---|---|
+| `.section-head{` | index.html | 68 | existing CSS for section headers |
+| `/* Env pill (PROD) — uses gold tint */` | index.html | 126 | PROD pill CSS |
+| `.ibtn{` | index.html | 221 | existing icon-button CSS (template for `.tbtn`) |
+| `/* Incidents timeline strip */` | index.html | 279 | incidents timeline CSS |
+| `<span class="env-pill">` | index.html | 500 | PROD pill markup |
+| `<!-- Auto-refresh toggle -->` | index.html | 531 | auto toggle markup |
+| `<div class="section-head" id="sec-cost">` | index.html | 542 | first section head |
+| `<span class="dot ok"></span>armed` | index.html | 567 | decorative budget dot |
+| `<span id="inc-count">3</span> incidents in 24h` | index.html | 643 | incidents sub-text |
+| `<!-- Incidents timeline (GCP Ops) -->` | index.html | 646 | incidents card |
+| `<div class="section-head" id="sec-requests">` | index.html | 669 | requests section head |
+| `<span class="badge badge-ok">2xx <span id="sc-2"` | index.html | 697 | status-code badges (to delete) |
+| `<div id="statusBars"` | index.html | 712 | status bars container |
+| `<thead><tr><th>started</th>` | index.html | 832 | backups table header (status col to drop) |
+| `<button id="sql-run" class="ibtn">` | index.html | 967 | SQL run button |
+| `<select id="sql-history" class="ibtn">` | index.html | 970 | SQL history select |
+| `<div id="sql-result"` | index.html | 974 | SQL result container (to replace) |
+| `.sql-error{` | index.html | 1088 | old SQL error CSS (will be superseded) |
+| `const STATE = {` | index.html | 1111 | STATE object |
+| `async function genData(range){` | index.html | 1149 | fetch `/metrics` |
+| `function genDataMock(range){` | index.html | 1221 | mock generator (gate behind preview flag) |
+| `function drawRequestChart(` | index.html | 1455 | chart renderer (stroke colors) |
+| `async function refreshAll(){` | index.html | 1558 | refresh entry point (rewrite for empty data) |
+| `function renderServices(){` | index.html | 1568 | service cards (full rewrite) |
+| `function renderRequests(){` | index.html | 1625 | status bars live here |
+| `function renderBackups(){` | index.html | 1749 | backups table row template |
+| `function renderAll(){` | index.html | 1904 | orchestrator |
+| `document.getElementById('auto').addEventListener` | index.html | 2085 | auto toggle handler (remove) |
+| `function setAuto(on){` | index.html | 2077 | setAuto helper (delete) |
+| `refreshAll();` / `setAuto(true);` | index.html | 2121 | boot |
+| `function initSQL() {` | controls.js | 359 | SQL console init |
+| `async function runSQL() {` | controls.js | 396 | SQL run handler (update for new markup) |
+| `function renderSQLTable(container, data)` | controls.js | 421 | SQL table renderer (reuse; tighten error path) |
+| `backend/monitor/tests/test_main.py` | — | 1 | smoke tests — extend here |
+
+**Preview server (already wired):** via Claude Code use `preview_start` with name `monitor-preview`. Boots at `http://127.0.0.1:8765`. Two URLs:
+- `/?preview=1` — mock data
+- `/` — empty-state
+
+---
+
+## Task 0: Prep the branch
+
+**Files:** None yet.
+
+- [ ] **Step 1: Create branch off `development`**
+
+```bash
+git fetch origin
+git checkout development
+git pull --ff-only origin development
+git checkout -b feature/ast-78-monitor-dashboard-polish
+git status
+```
+
+Expected: `On branch feature/ast-78-monitor-dashboard-polish` and `nothing to commit, working tree clean`.
+
+- [ ] **Step 2: Confirm current state renders**
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+PREVIEW_PID=$!
+sleep 1
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8765/
+curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:8765/static/controls.js
+kill $PREVIEW_PID
+```
+
+Expected: `200` and `200`.
+
+
+---
+
+## Task 1: Add shared CSS helpers
+
+**Commit message:** `[backend] AST-78 add shared CSS helpers for polish pass`
+
+**Files:** Modify `backend/monitor/static/index.html` — append inside the inline `<style>` block ending at L338.
+
+**Context:** Adds seven new style rulesets referenced by later tasks. No markup changes yet — pure additions slotted in just before the closing `</style>` at L338.
+
+- [ ] **Step 1: Open `backend/monitor/static/index.html` and locate the last media-query block**
+
+Search for this exact block (approximately L333–L337):
+
+```css
+  /* Media break — tighter mobile */
+  @media (max-width: 640px){
+    .log{ grid-template-columns: 64px 64px 1fr; gap: 8px; font-size:11px; }
+    .chart-wrap{ min-height:140px; }
+  }
+</style>
+```
+
+- [ ] **Step 2: Insert new CSS rules immediately BEFORE the `</style>` close tag**
+
+Replace the existing block above with the block below (keeps the media query, appends the polish-pass helpers, then closes `</style>`):
+
+```css
+  /* Media break — tighter mobile */
+  @media (max-width: 640px){
+    .log{ grid-template-columns: 64px 64px 1fr; gap: 8px; font-size:11px; }
+    .chart-wrap{ min-height:140px; }
+  }
+
+  /* ─── AST-78 polish-pass helpers ─────────────────────────────── */
+
+  /* AST-87 — solid-accent primary button */
+  .tbtn{
+    background: var(--gold); color: #0a0a0a; border: 1px solid var(--gold);
+    padding: 6px 14px; border-radius: 8px;
+    font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+    font-size: 12px; letter-spacing: .04em;
+    transition: transform .08s ease, opacity .12s;
+    cursor: pointer;
+  }
+  .tbtn:hover{ opacity: .9; }
+  .tbtn:active{ transform: scale(.97); }
+
+  /* AST-87 — styled native <select> */
+  .sel{
+    background: var(--surface); color: var(--white);
+    border: 1px solid var(--border);
+    padding: 6px 10px; border-radius: 8px;
+    font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+    font-size: 12px; cursor: pointer;
+  }
+
+  /* AST-88 — red-tinted SQL error box (supersedes the older .sql-error below) */
+  .sql-error{
+    background: rgba(255,107,107,.08);
+    border: 1px solid rgba(255,107,107,.4);
+    color: #FF9A9A;
+    padding: 10px 12px; border-radius: 8px;
+    font-family: "JetBrains Mono", ui-monospace, Menlo, monospace;
+    white-space: pre-wrap;
+  }
+
+  /* AST-91 — single scroll wrapper for every dashboard table */
+  .table-scroll{ max-height: 360px; overflow: auto; border-radius: 8px; }
+  .table-scroll thead th{
+    position: sticky; top: 0; background: var(--surface); z-index: 1;
+  }
+
+  /* AST-83 — collapsible section heads */
+  .section-head{ cursor: pointer; user-select: none; }
+  .section-head .chev{ transition: transform .18s ease; flex-shrink: 0; }
+  .section-head.collapsed .chev{ transform: rotate(-90deg); }
+  .section-body.collapsed{ display: none; }
+
+  /* AST-78-ext2 — 3D flip wrapper for service cards */
+  .svc-flip{ perspective: 1200px; }
+  .svc-flip-inner{
+    position: relative; transition: transform .5s;
+    transform-style: preserve-3d;
+  }
+  .svc-flip.flipped .svc-flip-inner{ transform: rotateY(180deg); }
+  .svc-face{
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+  }
+  .svc-face.back{
+    position: absolute; inset: 0; transform: rotateY(180deg);
+    background: var(--surface);
+    border-radius: 8px; padding: 14px;
+    display: flex; flex-direction: column; gap: 8px;
+  }
+  .svc-face.back .term-body{
+    flex: 1;
+    background: #0a0a0b; border: 1px solid var(--border); border-radius: 6px;
+    padding: 10px; font-family: "JetBrains Mono", monospace; font-size: 12px;
+    color: var(--body);
+    overflow: auto;
+  }
+  .svc-face.back .term-close{
+    position: absolute; top: 8px; right: 8px;
+    width: 22px; height: 22px;
+    display: inline-flex; align-items: center; justify-content: center;
+    color: var(--muted); background: transparent; border: 0; cursor: pointer;
+    border-radius: 4px;
+  }
+  .svc-face.back .term-close:hover{ color: var(--white); background: var(--elevated); }
+
+  /* AST-86 — skeleton / no-data */
+  .svc-dim{ opacity: .5; filter: grayscale(.3); }
+  .spark-empty{ font-size: 10px; color: var(--muted); letter-spacing: .12em; }
+</style>
+```
+
+The older `.sql-error` inside the second `<style>` block near L1088 is superseded by the new rule (both selectors have equal specificity, the new one appears first); Task 7 deletes the old line.
+
+- [ ] **Step 3: Preview-server sanity check**
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+PREVIEW_PID=$!
+sleep 1
+curl -s http://127.0.0.1:8765/ | grep -c 'table-scroll'
+curl -s http://127.0.0.1:8765/ | grep -c 'section-head.collapsed'
+curl -s http://127.0.0.1:8765/ | grep -c 'svc-flip'
+kill $PREVIEW_PID
+```
+
+Expected each grep: `>= 1`. Open `http://127.0.0.1:8765/?preview=1` in the preview tab and confirm the dashboard still renders identically — no visual change yet.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/monitor/static/index.html
+git commit -m "$(cat <<'MSG'
+[backend] AST-78 add shared CSS helpers for polish pass
+
+Ten rulesets added inside the main <style> block. No markup or
+behavior changes yet — these are slot-ins for subsequent commits:
+tbtn/sel (AST-87), sql-error (AST-88), table-scroll (AST-91),
+collapsible section-head (AST-83), svc-flip/svc-face (AST-78-ext2),
+svc-dim/spark-empty (AST-86).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+---
+
+## Task 2: Dashboard removals
+
+**Commit message:** `[backend] AST-79 AST-80 AST-81 AST-89 AST-90 monitor dashboard removals`
+
+**Files:** Modify `backend/monitor/static/index.html` (five independent deletions).
+
+**Context:** Pure deletions — PROD pill, auto-refresh toggle UI + handler + `STATE.auto` branch, decorative dot on `budget alert · armed`, incidents timeline card + section-head sub-text, `STATUS` column from backups history table.
+
+- [ ] **Step 1: AST-79 — remove the PROD env-pill**
+
+In `index.html` around L500, delete this line:
+
+```html
+    <span class="env-pill"><span class="dot ok"></span>PROD</span>
+```
+
+The surrounding flex layout handles the gap cleanly.
+
+- [ ] **Step 2: AST-81 — remove the auto-refresh toggle UI**
+
+In `index.html` around L531–L535, delete these four lines:
+
+```html
+    <!-- Auto-refresh toggle -->
+    <div class="flex items-center gap-2">
+      <span class="text-[11px] text-muted hidden sm:inline">auto</span>
+      <span id="auto" class="tgl on" role="switch" aria-checked="true"></span>
+    </div>
+```
+
+- [ ] **Step 3: AST-81 — simplify STATE, remove setAuto, keep the 30s timer running unconditionally**
+
+In `index.html`'s inline `<script>` block, find the `STATE` object (~L1111) and remove the `auto: true,` and `autoTimer: null,` lines. Final shape:
+
+```js
+const STATE = {
+  range: '6h',
+  logFilter: '',
+  svcFilter: 'all',
+  data: null,
+};
+```
+
+Find the `setAuto` function + click listener (~L2077–L2085) and replace the whole block with:
+
+```js
+// AST-81 — auto-refresh ticks unconditionally every 30s (no user toggle).
+setInterval(() => { refreshAll(); }, 30_000);
+```
+
+Find the boot call at the bottom of the script (~L2121–L2122):
+
+```js
+refreshAll();
+setAuto(true);
+```
+
+Replace with just:
+
+```js
+refreshAll();
+```
+
+- [ ] **Step 4: AST-80 — remove the decorative green dot on `budget alert · armed`**
+
+In `index.html` find the KV row for budget alert (~L565–L568):
+
+```html
+          <div class="kv">
+            <span class="k">budget alert</span>
+            <span class="v flex items-center gap-1.5"><span class="dot ok"></span>armed</span>
+          </div>
+```
+
+Replace with:
+
+```html
+          <div class="kv">
+            <span class="k">budget alert</span>
+            <span class="v">armed</span>
+          </div>
+```
+
+The `WITHIN CAPS` badge dot at L545 and the `APPROACHING CAP` branch inside `renderCost` stay untouched — they are semantic.
+
+- [ ] **Step 5: AST-89 — delete the incidents timeline block and its sub-text**
+
+In `index.html` find the Service Health section head (~L640–L644) and replace:
+
+```html
+  <div class="section-head" id="sec-services">
+    <span class="crumb">astral / oci / <span class="cur">service health</span></span>
+    <span class="rule"></span>
+    <span class="mono text-[11px] text-muted">docker compose ps · 6 services · <span id="inc-count">3</span> incidents in 24h</span>
+  </div>
+```
+
+with:
+
+```html
+  <div class="section-head" id="sec-services">
+    <span class="crumb">astral / oci / <span class="cur">service health</span></span>
+    <span class="rule"></span>
+    <span class="mono text-[11px] text-muted">docker compose ps · 6 services</span>
+  </div>
+```
+
+Then delete the entire `<!-- Incidents timeline (GCP Ops) -->` section directly below (~L646–L660):
+
+```html
+  <!-- Incidents timeline (GCP Ops) -->
+  <section class="card p-3 sm:p-4 mb-3">
+    <div class="flex items-center justify-between mb-2">
+      <div class="text-[11px] tracking-[.14em] uppercase text-muted">Incidents · last 24h</div>
+      <div class="flex items-center gap-2 text-[11px] text-muted mono">
+        <span class="flex items-center gap-1"><span class="dot" style="background:var(--warning); width:6px; height:6px;"></span>warn</span>
+        <span class="flex items-center gap-1"><span class="dot crit" style="width:6px; height:6px; box-shadow:none;"></span>crit</span>
+        <span class="flex items-center gap-1"><span class="dot" style="background:var(--gold); width:6px; height:6px;"></span>info</span>
+      </div>
+    </div>
+    <div class="timeline" id="timeline">
+      <div class="now-line" style="right:0"></div>
+    </div>
+    <div class="relative mt-1" style="height:12px;" id="timeline-labels"></div>
+  </section>
+```
+
+- [ ] **Step 6: AST-90 — drop STATUS column from backups history table**
+
+In `index.html` find the table header (~L832):
+
+```html
+          <thead><tr><th>started</th><th>took</th><th>size</th><th>status</th></tr></thead>
+```
+
+Replace with:
+
+```html
+          <thead><tr><th>started</th><th>took</th><th>size</th></tr></thead>
+```
+
+Then in the inline `<script>` find `renderBackups` (~L1749) and simplify — the new function keeps the three-column row template only. Replace the existing function body so the table row template no longer emits a `<td>` with the status badge. The countdown block (`document.getElementById('bk-next')...`) stays unchanged. After editing, the function should only emit three cells per row: started, duration, size.
+
+- [ ] **Step 7: Preview verify**
+
+Start preview, open `http://127.0.0.1:8765/?preview=1`, and verify:
+
+- No green `PROD` pill near "oci monitor".
+- No `auto` toggle on the right of the time-range tabs.
+- `budget alert · armed` no longer has a green dot (but `WITHIN CAPS` top-right still does).
+- No "Incidents · last 24h" card above the service cards.
+- Backups history table shows only 3 columns: `STARTED / TOOK / SIZE`.
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+PREVIEW_PID=$!
+sleep 1
+! curl -s http://127.0.0.1:8765/ | grep -q 'env-pill'         && echo "✓ env-pill removed"
+! curl -s http://127.0.0.1:8765/ | grep -q 'id="auto"'        && echo "✓ auto toggle removed"
+! curl -s http://127.0.0.1:8765/ | grep -q 'Incidents · last' && echo "✓ incidents strip removed"
+! curl -s http://127.0.0.1:8765/ | grep -q '>status</th>'     && echo "✓ backups status column removed"
+kill $PREVIEW_PID
+```
+
+Expected: four `✓` lines.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/monitor/static/index.html
+git commit -m "$(cat <<'MSG'
+[backend] AST-79 AST-80 AST-81 AST-89 AST-90 monitor dashboard removals
+
+Delete PROD env-pill, auto-refresh toggle (timer runs unconditionally
+at 30s), decorative dot on budget-alert-armed, incidents timeline card
++ section-head sub-text, and STATUS column from backups history table.
+
+Fixes AST-79
+Fixes AST-80
+Fixes AST-81
+Fixes AST-89
+Fixes AST-90
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+
+---
+
+## Task 3: Collapsible section heads with localStorage persistence
+
+**Commit message:** `[backend] AST-83 collapsible section-heads with localStorage`
+
+**Files:** Modify `backend/monitor/static/index.html`.
+
+**Context:** Every `.section-head` div needs a leading chevron SVG; the content directly below needs wrapping as `.section-body`; a delegated click handler toggles `.collapsed` on both and persists the map to `localStorage.monitor_collapsed_v1`. Defaults: `sec-cost` and `sec-services` expanded; everything else collapsed.
+
+Twelve section heads in document order: `sec-cost`, `sec-services`, `sec-requests`, `sec-arq`, `sec-storage`, `sec-backups`, `sec-cert`, `sec-logs`, `sec-flags`, `sec-deploys`, `sec-sql`, `sec-audit`.
+
+- [ ] **Step 1: Add a chevron SVG to every section-head**
+
+For EACH of the 12 section-head divs, insert this SVG as the FIRST child (immediately after the opening `<div class="section-head" id="sec-...">` tag):
+
+```html
+<svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
+```
+
+Example — `sec-cost` (L542) becomes:
+
+```html
+  <div class="section-head" id="sec-cost">
+    <svg class="chev" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" style="color:var(--muted)"><path d="m6 9 6 6 6-6"/></svg>
+    <span class="crumb">astral / oci / <span class="cur">cost &amp; always-free</span></span>
+    <span class="rule"></span>
+    <span class="badge badge-ok"><span class="dot ok"></span>WITHIN CAPS</span>
+  </div>
+```
+
+Repeat for the other 11. The chevron sits BEFORE the `.crumb` span in every case.
+
+- [ ] **Step 2: Wrap each section's content in a `.section-body` div**
+
+For each section-head `<div class="section-head" id="sec-X">...</div>`, wrap everything that follows it (up to but not including the NEXT section-head or the `</main>` close tag) in:
+
+```html
+<div class="section-body" data-for="sec-X">
+  ... existing content ...
+</div>
+```
+
+Concretely — for each section listed, insert `<div class="section-body" data-for="sec-X">` right after the section-head's closing `</div>`, and insert the closing `</div>` right before the NEXT section-head's opening `<div>` (or before `<footer>` for the final `sec-audit` wrapper).
+
+Example — cost section wrapping:
+
+```html
+  <div class="section-head" id="sec-cost">
+    <svg class="chev" ... />
+    <span class="crumb">astral / oci / <span class="cur">cost &amp; always-free</span></span>
+    <span class="rule"></span>
+    <span class="badge badge-ok"><span class="dot ok"></span>WITHIN CAPS</span>
+  </div>
+
+  <div class="section-body" data-for="sec-cost">
+    <section class="card p-4 sm:p-5">
+      ... existing cost content unchanged ...
+    </section>
+  </div>
+
+
+  <!-- ─── 2. SERVICE HEALTH GRID ─── -->
+  <div class="section-head" id="sec-services">
+    ...
+```
+
+Apply the same pattern to all 12 sections.
+
+- [ ] **Step 3: Add collapsible state + delegated handler in the inline script**
+
+At the top of the inline `<script>` block (right below `const STATE = { ... };` definition, ~L1118), insert:
+
+```js
+// AST-83 — collapsible sections
+const COLLAPSE_KEY = 'monitor_collapsed_v1';
+const COLLAPSE_DEFAULTS = {
+  'sec-cost':     false,
+  'sec-services': false,
+  'sec-requests': true,
+  'sec-arq':      true,
+  'sec-storage':  true,
+  'sec-backups':  true,
+  'sec-cert':     true,
+  'sec-logs':     true,
+  'sec-flags':    true,
+  'sec-deploys':  true,
+  'sec-sql':      true,
+  'sec-audit':    true,
+};
+STATE.collapsed = (() => {
+  try {
+    const raw = localStorage.getItem(COLLAPSE_KEY);
+    if (!raw) return Object.assign({}, COLLAPSE_DEFAULTS);
+    return Object.assign({}, COLLAPSE_DEFAULTS, JSON.parse(raw));
+  } catch (_) {
+    return Object.assign({}, COLLAPSE_DEFAULTS);
+  }
+})();
+
+function applyCollapsed(id){
+  const head = document.getElementById(id);
+  const body = document.querySelector(`.section-body[data-for="${id}"]`);
+  if (!head || !body) return;
+  const isCollapsed = !!STATE.collapsed[id];
+  head.classList.toggle('collapsed', isCollapsed);
+  body.classList.toggle('collapsed', isCollapsed);
+}
+
+function applyAllCollapsed(){
+  for (const id of Object.keys(COLLAPSE_DEFAULTS)) applyCollapsed(id);
+}
+
+function toggleSection(id){
+  STATE.collapsed[id] = !STATE.collapsed[id];
+  try { localStorage.setItem(COLLAPSE_KEY, JSON.stringify(STATE.collapsed)); } catch(_) {}
+  applyCollapsed(id);
+}
+
+// Delegated click handler for every section head
+document.addEventListener('click', (e) => {
+  const head = e.target.closest('.section-head');
+  if (!head || !head.id || !(head.id in COLLAPSE_DEFAULTS)) return;
+  // Ignore clicks that target interactive children
+  if (e.target.closest('button')) return;
+  toggleSection(head.id);
+});
+```
+
+At the bottom of the script (right after `refreshAll();`), add:
+
+```js
+applyAllCollapsed();
+```
+
+- [ ] **Step 4: Preview verify**
+
+Start preview, open `http://127.0.0.1:8765/?preview=1`. Expect:
+
+- Only the COST and SERVICE HEALTH sections visible on first load; all others show their section-head (with a rotated `<` chevron) but no body.
+- Clicking any section-head toggles visibility; chevron rotates.
+- Refresh the page — state persists.
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+PREVIEW_PID=$!
+sleep 1
+curl -s http://127.0.0.1:8765/ | grep -c 'section-body data-for'
+curl -s http://127.0.0.1:8765/ | grep -c 'class="chev"'
+kill $PREVIEW_PID
+```
+
+Expected: each grep ≥ 12.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/monitor/static/index.html
+git commit -m "$(cat <<'MSG'
+[backend] AST-83 collapsible section-heads with localStorage
+
+Each .section-head div gets a leading rotating chevron and toggles a
+sibling .section-body wrapper. State persisted in
+localStorage.monitor_collapsed_v1 (v-suffix so future default changes
+can invalidate). Defaults: sec-cost and sec-services expanded; all
+other 10 sections collapsed on first visit.
+
+Fixes AST-83
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+---
+
+## Task 4: Request chart colors + sticky-header table scroll
+
+**Commit message:** `[backend] AST-85 AST-91 request chart colors + sticky-header table scroll`
+
+**Files:** Modify `backend/monitor/static/index.html`.
+
+**Context:** AST-85 changes two hex values in `drawRequestChart` + the two legend swatches next to `rps` and `p95`. AST-91 wraps six dashboard tables in `<div class="table-scroll">` — this activates the `max-height: 360px; overflow: auto;` CSS from Task 1; the sticky `thead` is handled by the global `.table-scroll thead th` selector. (The seventh table — SQL results — is wrapped in Task 7.)
+
+- [ ] **Step 1: AST-85 — update chart colors in `drawRequestChart`**
+
+In `index.html` find `drawRequestChart` (~L1455). Inside, update the three color references.
+
+Replace:
+
+```js
+    <path d="${rpsArea}" fill="#C9A84C" fill-opacity="0.10"/>
+    <path d="${rpsD}" fill="none" stroke="#C9A84C" stroke-width="1.4" stroke-linejoin="round"/>
+    <path d="${p95D}" fill="none" stroke="#FFA726" stroke-width="1.2" stroke-dasharray="3 3" stroke-linejoin="round"/>
+```
+
+with:
+
+```js
+    <path d="${rpsArea}" fill="#4FC3F7" fill-opacity="0.10"/>
+    <path d="${rpsD}" fill="none" stroke="#4FC3F7" stroke-width="1.4" stroke-linejoin="round"/>
+    <path d="${p95D}" fill="none" stroke="#FF6B6B" stroke-width="1.2" stroke-dasharray="3 3" stroke-linejoin="round"/>
+```
+
+- [ ] **Step 2: AST-85 — update the legend swatches in the requests summary card**
+
+In `index.html` find the two legend lines (~L684 and ~L688):
+
+```html
+              <div class="text-[11px] text-muted mono">rps · <span style="color:var(--gold)">■</span> rps</div>
+```
+
+Change `color:var(--gold)` to `color:#4FC3F7` on the rps legend.
+
+```html
+              <div class="text-[11px] text-muted mono">p95 · <span style="color:var(--warning)">■</span> p95</div>
+```
+
+Change `color:var(--warning)` to `color:#FF6B6B` on the p95 legend.
+
+- [ ] **Step 3: AST-91 — wrap the Slowest Endpoints table**
+
+Find (~L714–L718):
+
+```html
+      <div class="text-[11px] tracking-[.14em] uppercase text-muted mb-2">Slowest endpoints</div>
+      <table class="z">
+        <thead><tr><th>endpoint</th><th class="text-right">p95</th><th class="text-right">n</th></tr></thead>
+        <tbody id="slowest"></tbody>
+      </table>
+```
+
+Wrap the `<table>` in `<div class="table-scroll">...</div>` so the final structure is:
+
+```html
+      <div class="text-[11px] tracking-[.14em] uppercase text-muted mb-2">Slowest endpoints</div>
+      <div class="table-scroll">
+        <table class="z">
+          <thead><tr><th>endpoint</th><th class="text-right">p95</th><th class="text-right">n</th></tr></thead>
+          <tbody id="slowest"></tbody>
+        </table>
+      </div>
+```
+
+- [ ] **Step 4: AST-91 — wrap the ARQ Completed and ARQ Failed tables**
+
+Repeat the same wrapping pattern for:
+
+1. The completed jobs table (~L768) — contents `<tbody id="completed">`
+2. The failed jobs table (~L780) — contents `<tbody id="failed">`
+
+Each `<table class="z">...</table>` becomes `<div class="table-scroll"><table class="z">...</table></div>`.
+
+- [ ] **Step 5: AST-91 — wrap the Backups History, Recent Deploys, and Audit Log tables**
+
+Same pattern again for:
+
+3. Backups history table (~L831) — `<tbody id="bk-rows">` (3 columns after Task 2)
+4. Recent deploys table (~L947) — `<tbody id="deploys-rows">`
+5. Audit log table (~L985) — `<tbody id="audit-rows">`
+
+Each `<table class="z">...</table>` becomes `<div class="table-scroll"><table class="z">...</table></div>`.
+
+- [ ] **Step 6: Preview verify**
+
+Start preview at `/?preview=1`. Expand every section (click chevrons). Verify:
+
+- RPS line is sky blue, p95 dashed line is coral red (check the line chart inside the requests section).
+- Legend swatches match those colors.
+- Each table with more than ~8 rows scrolls internally; `thead` row stays pinned at top while scrolling.
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+PREVIEW_PID=$!
+sleep 1
+curl -s http://127.0.0.1:8765/ | grep -c 'table-scroll'
+curl -s http://127.0.0.1:8765/ | grep -c '#4FC3F7'
+curl -s http://127.0.0.1:8765/ | grep -c '#FF6B6B'
+kill $PREVIEW_PID
+```
+
+Expected: first grep ≥ 6 (five wrapped tables + CSS rule from Task 1), second ≥ 2 (chart + legend), third ≥ 2.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/monitor/static/index.html
+git commit -m "$(cat <<'MSG'
+[backend] AST-85 AST-91 request chart colors + sticky-header table scroll
+
+Two small unrelated polish items bundled:
+- drawRequestChart: RPS #4FC3F7, p95 #FF6B6B; legend swatches match.
+- Every dashboard table wraps in <div class="table-scroll"> (six
+  tables in this commit: slowest, ARQ completed/failed, backups
+  history, recent deploys, audit log. SQL results wrapper lands in
+  Task 7.) Global .table-scroll thead th selector handles the
+  sticky-header CSS.
+
+Fixes AST-85
+Fixes AST-91
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+---
+
+## Task 5: Status-code bar toggles (AST-84)
+
+**Commit message:** `[backend] AST-84 status-code bar toggles in requests panel`
+
+**Files:** Modify `backend/monitor/static/index.html`.
+
+**Context:** The four `2xx/3xx/4xx/5xx` count badges at the top-right of the requests summary card are DELETED. The STATUS CODES bar rows in the right panel become the toggles — click a row to dim/restore. State lives in `STATE.statusFilter` (a `Set`). No chart interaction; filtering is cosmetic on the bars only.
+
+- [ ] **Step 1: Delete the four top-right status-code badges**
+
+In `index.html` find the badge block inside the requests summary card (~L696–L701):
+
+```html
+        <div class="flex gap-2 text-[11px] text-muted mono">
+          <span class="badge badge-ok">2xx <span id="sc-2" class="mono text-body ml-1">18,421</span></span>
+          <span class="badge badge-muted">3xx <span id="sc-3" class="mono text-body ml-1">320</span></span>
+          <span class="badge badge-warn">4xx <span id="sc-4" class="mono text-body ml-1">87</span></span>
+          <span class="badge badge-crit">5xx <span id="sc-5" class="mono text-body ml-1">3</span></span>
+        </div>
+```
+
+Delete the entire block (opening `<div>` through closing `</div>`).
+
+- [ ] **Step 2: Remove the four `sc-*` id references from `renderRequests`**
+
+In `index.html` find `renderRequests` (~L1625). Delete these four lines inside the no-traffic branch (~L1642–L1645):
+
+```js
+    document.getElementById('sc-2').textContent = '0';
+    document.getElementById('sc-3').textContent = '0';
+    document.getElementById('sc-4').textContent = '0';
+    document.getElementById('sc-5').textContent = '0';
+```
+
+Delete these four lines in the main branch (~L1657–L1660):
+
+```js
+  document.getElementById('sc-2').textContent = r.status_codes['2xx'].toLocaleString();
+  document.getElementById('sc-3').textContent = r.status_codes['3xx'].toLocaleString();
+  document.getElementById('sc-4').textContent = r.status_codes['4xx'].toLocaleString();
+  document.getElementById('sc-5').textContent = r.status_codes['5xx'].toLocaleString();
+```
+
+- [ ] **Step 3: Add the filter Set to STATE**
+
+Near the collapsible state block added in Task 3, add one line:
+
+```js
+STATE.statusFilter = new Set();  // AST-84 — codes in the set are DIMMED
+```
+
+Semantic: empty set = all shown; code in set = that row is dimmed. Simpler than seeding all four codes (which would render everything dimmed on first load).
+
+- [ ] **Step 4: Emit clickable rows in the status-bars render block**
+
+Still in `renderRequests`, find the status-bars render block (~L1662–L1674). Rewrite it so each row gets a `sc-row` class, a `data-code` attribute, the `svc-dim` class when the code is in the filter set, and `cursor:pointer` for affordance. The existing structure (flex header with code + count + percent, then `.bar-track`) stays the same — just wrapped in a clickable container.
+
+Concretely, each row now emits (template):
+
+```
+<div class="sc-row{dim}" data-code="{k}" style="cursor:pointer">
+  ... existing flex+bar content unchanged ...
+</div>
+```
+
+where `dim` is `" svc-dim"` when `STATE.statusFilter.has(k)`, empty string otherwise.
+
+- [ ] **Step 5: Wire the click handler**
+
+At the end of the `renderRequests` function (just before its closing `}`), add:
+
+```js
+  // AST-84 — attach click handlers to .sc-row
+  document.querySelectorAll('#statusBars .sc-row').forEach(row => {
+    row.addEventListener('click', () => {
+      const code = row.dataset.code;
+      if (STATE.statusFilter.has(code)) STATE.statusFilter.delete(code);
+      else STATE.statusFilter.add(code);
+      row.classList.toggle('svc-dim', STATE.statusFilter.has(code));
+    });
+  });
+```
+
+- [ ] **Step 6: Preview verify**
+
+Start preview at `/?preview=1`, expand the REQUESTS section. Verify:
+
+- Top-right of the requests summary card no longer shows the four count pills.
+- Right panel STATUS CODES: clicking any row dims it; clicking again restores.
+- The line chart is unchanged (no filter interaction).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/monitor/static/index.html
+git commit -m "$(cat <<'MSG'
+[backend] AST-84 status-code bar toggles in requests panel
+
+Remove the four count-pill badges (2xx/3xx/4xx/5xx) from the top-right
+of the requests summary card. The four rows in the STATUS CODES right
+panel become click-to-dim toggles — clicking a row applies svc-dim;
+click again to restore. State in STATE.statusFilter (Set). No
+interaction with drawRequestChart — filtering is cosmetic on the bars.
+
+Fixes AST-84
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+
+---
+
+## Task 6: Service-card skeleton + empty states (AST-86)
+
+**Commit message:** `[backend] AST-86 service-card skeleton + no-data empty state`
+
+**Files:** Modify `backend/monitor/static/index.html`.
+
+**Context:** The most substantial single change. Three related edits:
+
+1. `renderServices` rewritten to drive from a fixed `SVC_ORDER` constant, not from `STATE.data.services`. Missing entries render with `NO DATA` badge + `svc-dim` body + placeholder values.
+2. `refreshAll`'s catch branch sets `STATE.data = emptyData()` (new typed-empty helper) and calls `renderAll()`.
+3. `genData` short-circuits to `genDataMock` at its top when `window.__MONITOR_PREVIEW__ === true`. An inline `<script>` in `index.html` sets the flag from `?preview=1`.
+
+- [ ] **Step 1: Add the preview-flag setter as the very first inline script**
+
+In `index.html`, find the opening `<script>` at L1091 (the one immediately followed by the `/* ========== astral · oci monitor — mock data engine ... */` comment).
+
+Insert BEFORE that `<script>` tag:
+
+```html
+<script>
+// AST-86 preview-flag: enables genDataMock in the local preview server.
+// Prod URLs never carry ?preview — nginx strips query strings on / as well,
+// so this flag can only be set through the local preview server.
+window.__MONITOR_PREVIEW__ = new URLSearchParams(location.search).has('preview');
+</script>
+<script>
+```
+
+The second `<script>` opens the existing main block.
+
+- [ ] **Step 2: Gate `genDataMock` behind the preview flag inside `genData`**
+
+Find `genData` at L1149:
+
+```js
+async function genData(range){
+  const resp = await fetch('/metrics?range=' + encodeURIComponent(range), {credentials: 'include'});
+  if(!resp.ok){
+    throw new Error('metrics fetch failed: ' + resp.status);
+  }
+  return normalizeMetrics(await resp.json());
+}
+```
+
+Replace with:
+
+```js
+async function genData(range){
+  // AST-86 — preview-server escape hatch. Prod never sets this flag.
+  if (window.__MONITOR_PREVIEW__) return genDataMock(range);
+  const resp = await fetch('/metrics?range=' + encodeURIComponent(range), {credentials: 'include'});
+  if(!resp.ok){
+    throw new Error('metrics fetch failed: ' + resp.status);
+  }
+  return normalizeMetrics(await resp.json());
+}
+```
+
+- [ ] **Step 3: Add the `emptyData` helper**
+
+Immediately after `genData` (so ~after L1157), add:
+
+```js
+// AST-86 — typed-empty data object used when /metrics is unreachable.
+// Shape matches what renderers expect so they can walk it safely.
+function emptyData(){
+  return {
+    schema_version: '1.0.0',
+    generated_at: new Date().toISOString(),
+    build: '—',
+    region: '—',
+    tenancy_ocid: '—',
+    instance_ocid: '—',
+    cost: null,
+    services: [],
+    requests: { window: '—', series_rps: [], series_p95_ms: [], status_codes: {'2xx':0,'3xx':0,'4xx':0,'5xx':0}, total: 0, slowest: [] },
+    arq: { queue_depth: 0, in_flight: 0, workers: 0, completed_24h: 0, failed_24h: 0, active: [], recent_completed: [], recent_failed: [] },
+    storage: null,
+    backups: { status: '—', recent_runs: [], next_run_in_s: 0, bucket: '—', retention_days: 0 },
+    cert: null,
+    logs: [],
+  };
+}
+```
+
+- [ ] **Step 4: Rewrite `refreshAll` so the catch branch renders empty data**
+
+Find (~L1558–L1566):
+
+```js
+async function refreshAll(){
+  try {
+    STATE.data = await genData(STATE.range);
+    renderAll();
+  } catch(e){
+    console.error('refreshAll failed', e);
+    toast('metrics unreachable');
+  }
+}
+```
+
+Replace with:
+
+```js
+async function refreshAll(){
+  try {
+    STATE.data = await genData(STATE.range);
+  } catch(e){
+    console.error('refreshAll failed', e);
+    STATE.data = emptyData();
+    if (!STATE._warnedUnreachable){
+      toast('metrics unreachable');
+      STATE._warnedUnreachable = true;
+    }
+  }
+  renderAll();
+}
+```
+
+- [ ] **Step 5: Rewrite `renderServices`**
+
+Find the entire `renderServices` function at L1568–L1623. Replace it with the block below. The new function is driven by a static list; missing entries render a NO DATA skeleton.
+
+```js
+// AST-86 — six-card skeleton driven by static list, never by STATE.data.services.
+const SVC_ORDER = ['postgres','redis','fastapi','arq_worker','nginx','certbot'];
+const SVC_IMAGES = {
+  postgres:   'postgres:16-alpine',
+  redis:      'redis:7-alpine',
+  fastapi:    'astral/fastapi:—',
+  arq_worker: 'astral/worker:—',
+  nginx:      'nginx:1.25-alpine',
+  certbot:    'certbot/certbot:latest',
+};
+
+function renderServices(){
+  const grid = document.getElementById('svc-grid');
+  const entries = STATE.data.services || [];
+  const cards = SVC_ORDER.map(name => {
+    const s = entries.find(e => e && e.name === name);
+    const hasData = !!s;
+    const hasSpark = hasData && Array.isArray(s.spark) && s.spark.length > 0;
+
+    // Badge + tone
+    let badge, tone, lbl;
+    if (!hasData) {
+      badge = 'badge-warn'; tone = 'warn'; lbl = 'NO DATA';
+    } else if (s.health === 'healthy') {
+      badge = 'badge-ok'; tone = 'ok'; lbl = 'UP';
+    } else if (s.health === 'starting') {
+      badge = 'badge-warn'; tone = 'warn'; lbl = 'STARTING';
+    } else {
+      badge = 'badge-crit'; tone = 'crit'; lbl = 'DOWN';
+    }
+
+    const imageStr = hasData ? (s.image || SVC_IMAGES[name]) : SVC_IMAGES[name];
+    const [imageBase, imageTag] = imageStr.split(':');
+
+    const uptime = hasData ? fmtUptime(s.uptime_s) : '—';
+    const cpuMem = hasData
+      ? `${Number(s.cpu || 0).toFixed(1)}% · ${s.mem || 0}MB`
+      : '— · —';
+
+    const sparkMarkup = hasSpark
+      ? sparkSvg(s.spark, {tone: tone === 'ok' ? '' : tone})
+      : `<svg class="spark" viewBox="0 0 200 30" preserveAspectRatio="none" style="width:100%;height:30px"><text class="spark-empty" x="4" y="19">no data</text></svg>`;
+
+    // Footer by service (fall back to empty when data missing)
+    let footer = '<span class="mono text-[11px] text-muted">metrics unreachable</span>';
+    if (hasData) {
+      const extra = s.extra || {};
+      if (name === 'postgres')        footer = `<span class="mono text-[11px] text-muted">${extra.pg_connections ?? '—'}/${extra.pg_max_connections ?? '—'} conns</span>`;
+      else if (name === 'redis')      footer = `<span class="mono text-[11px] text-muted">${extra.ops_sec ?? '—'} ops/s · ${extra.keys ?? '—'} keys</span>`;
+      else if (name === 'fastapi')    footer = `<span class="mono text-[11px] text-muted">${extra.workers ?? '—'}w · ${extra.rps ?? '—'} rps</span>`;
+      else if (name === 'arq_worker') footer = `<span class="mono text-[11px] text-muted">${extra.jobs_active ?? '—'}/${extra.max ?? '—'} jobs</span>`;
+      else if (name === 'nginx')      footer = `<span class="mono text-[11px] text-muted">${extra.active_connections ?? '—'} conns · ${(extra.reqs_total ?? 0).toLocaleString()} req</span>`;
+      else if (name === 'certbot')    footer = `<span class="mono text-[11px] text-muted">next check ${extra.next_check_in ?? '—'}</span>`;
+    }
+
+    const bodyClass = hasData ? '' : ' svc-dim';
+    const containerId = hasData ? (s.container_id || '') : '';
+
+    return `
+    <div class="card svc-card p-4${bodyClass}" data-service-card="${name}">
+      <div class="flex items-start gap-3 svc-card-header">
+        <div class="elevated w-8 h-8 flex items-center justify-center text-muted" style="border-radius:8px">${svcIcon(name)}</div>
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2">
+            <span class="text-white font-semibold tracking-tight truncate">${name}</span>
+            <span class="badge ${badge}"><span class="dot ${tone}"></span>${lbl}</span>
+            <span class="flex-1"></span>
+            <button class="ibtn svc-refresh" style="width:24px;height:24px;" title="refresh ${name}" onclick="event.stopPropagation(); this.classList.add('spin'); setTimeout(()=>this.classList.remove('spin'),700); refreshService('${name}');">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
+            </button>
+          </div>
+          <div class="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted mono truncate">
+            <span class="truncate">${imageBase}</span>
+            <span style="color:var(--gold)">:${imageTag||'latest'}</span>
+          </div>
+        </div>
+      </div>
+      <div class="mt-3 flex items-baseline justify-between">
+        <div>
+          <div class="text-[11px] tracking-[.14em] uppercase text-muted">uptime</div>
+          <div class="mono text-sm text-white">${uptime}</div>
+        </div>
+        <div class="text-right">
+          <div class="text-[11px] tracking-[.14em] uppercase text-muted">cpu · mem</div>
+          <div class="mono text-sm text-white">${cpuMem}</div>
+        </div>
+      </div>
+      <div class="mt-2">
+        ${sparkMarkup}
+      </div>
+      <div class="mt-1 flex justify-between items-center">
+        <span class="copy" data-copy="${containerId}">${containerId.slice(0,12) || '—'} <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></span>
+        ${footer}
+      </div>
+    </div>`;
+  });
+  grid.replaceChildren();
+  const parser = new DOMParser();
+  const doc = parser.parseFromString('<div>' + cards.join('') + '</div>', 'text/html');
+  const src = doc.body.firstElementChild;
+  while (src && src.firstChild) grid.appendChild(src.firstChild);
+}
+```
+
+Note the final DOM assembly uses `DOMParser` + `replaceChildren` + `appendChild` to avoid direct assignment to `.innerHTML` on the grid container; this keeps the safe-DOM discipline consistent with the rest of the polish pass.
+
+- [ ] **Step 6: Preview verify BOTH modes**
+
+A. **Preview mode (mock data)** — open `http://127.0.0.1:8765/?preview=1`:
+
+- All 6 service cards render with UP badges + sparklines and real-looking CPU/MEM.
+- No toast on load.
+
+B. **Empty-state mode** — open `http://127.0.0.1:8765/` (no preview flag):
+
+- All 6 service cards STILL render, now with amber `NO DATA` badge, `—` placeholders, `no data` sparkline label, `metrics unreachable` footer, and the body is dimmed (`svc-dim`).
+- One `metrics unreachable` toast appears on first load, does NOT repeat.
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+PREVIEW_PID=$!
+sleep 1
+curl -s http://127.0.0.1:8765/           | grep -c 'SVC_ORDER'
+curl -s http://127.0.0.1:8765/?preview=1 | grep -c '__MONITOR_PREVIEW__'
+kill $PREVIEW_PID
+```
+
+Expected each: ≥ 1.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/monitor/static/index.html
+git commit -m "$(cat <<'MSG'
+[backend] AST-86 service-card skeleton + no-data empty state
+
+renderServices rewrite driven by a static SVC_ORDER list (postgres,
+redis, fastapi, arq_worker, nginx, certbot). Missing data entries
+render amber NO DATA badge + svc-dim body + em-dash placeholders and
+a 'no data' sparkline label; present-but-sparkless entries only show
+the sparkline fallback.
+
+refreshAll's catch branch now sets STATE.data to a typed-empty object
+and calls renderAll, so the six cards always draw. A _warnedUnreachable
+flag prevents toast spam on successive fetch failures.
+
+genData short-circuits to genDataMock when window.__MONITOR_PREVIEW__
+is true; an inline prelude script sets the flag from ?preview=1 query
+param. Prod never sees the flag.
+
+Fixes AST-86
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+---
+
+## Task 7: SQL run button + results section (AST-87, AST-88)
+
+**Commit message:** `[backend] AST-87 AST-88 SQL run button + results section`
+
+**Files:**
+- Modify `backend/monitor/static/index.html`
+- Modify `backend/monitor/static/controls.js`
+
+**Context:** AST-87 swaps classes on the SQL Run button + History select. AST-88 restructures the results area into a labeled, scrollable section and tightens the error path to use `textContent` only.
+
+- [ ] **Step 1: AST-87 / AST-88 — update the SQL console markup**
+
+In `index.html` find the SQL console section (~L964–L975):
+
+```html
+  <section class="card p-4 sm:p-5">
+    <textarea id="sql-input" rows="5" class="w-full bg-bg mono text-sm p-3 rounded-lg hairline" placeholder="SELECT id, title FROM comics ORDER BY added_at DESC LIMIT 10;"></textarea>
+    <div class="flex items-center gap-3 mt-3">
+      <button id="sql-run" class="ibtn">Run (Cmd/Ctrl+Enter)</button>
+      <span id="sql-status" class="text-[11px] text-muted mono"></span>
+      <div class="flex-1"></div>
+      <select id="sql-history" class="ibtn">
+        <option value="">History…</option>
+      </select>
+    </div>
+    <div id="sql-result" class="mt-3 overflow-auto" style="max-height:420px;"></div>
+  </section>
+```
+
+Replace with:
+
+```html
+  <section class="card p-4 sm:p-5">
+    <textarea id="sql-input" rows="5" class="w-full bg-bg mono text-sm p-3 rounded-lg hairline" placeholder="SELECT id, title FROM comics ORDER BY added_at DESC LIMIT 10;"></textarea>
+    <div class="flex items-center gap-3 mt-3">
+      <button id="sql-run" class="tbtn">Run ⌘↵</button>
+      <span id="sql-status" class="text-[11px] text-muted mono"></span>
+      <div class="flex-1"></div>
+      <select id="sql-history" class="sel">
+        <option value="">History…</option>
+      </select>
+    </div>
+    <div id="sql-results" class="hidden" style="margin-top:16px">
+      <div class="flex items-baseline justify-between mb-2">
+        <div class="text-[11px] tracking-[.14em] uppercase text-muted">Results</div>
+        <div id="sql-results-meta" class="mono text-[11px] text-muted"></div>
+      </div>
+      <div id="sql-results-body" class="table-scroll"></div>
+    </div>
+  </section>
+```
+
+Key changes: `ibtn` → `tbtn`, `Run (Cmd/Ctrl+Enter)` → `Run ⌘↵`, history `ibtn` → `sel`, results container becomes the `#sql-results` wrapper with label + meta + scrollable body.
+
+- [ ] **Step 2: AST-88 — update `runSQL` in controls.js to target new markup and tighten the error path**
+
+In `backend/monitor/static/controls.js` find `runSQL` at ~L396–L419.
+
+Update it so:
+- It reads `#sql-results` (wrapper), `#sql-results-body` (table container), and `#sql-results-meta` (row-count/duration span).
+- On first run, it removes the `hidden` class from the wrapper.
+- Success path: clears `#sql-status`, writes `"{n} rows · {ms}ms · TRUNCATED?"` into `#sql-results-meta` (NOT into status), and calls `renderSQLTable(body, data)`.
+- Error path: clears body, creates a `div.sql-error` via `document.createElement`, assigns `err.message` via `.textContent`, appends to body.
+
+The existing `renderSQLTable(container, data)` function (~L421) keeps its signature — no changes needed there; it already uses safe DOM methods (`createElement`, `textContent`).
+
+- [ ] **Step 3: Delete the old `.sql-error` CSS now that the main-style-block rule covers it**
+
+In `index.html` find the second `<style>` block around L1064–L1089. Locate these three lines (last block inside that style tag):
+
+```css
+  .sql-table{ width:100%; border-collapse:collapse; font-size:12px; }
+  .sql-table th, .sql-table td{ padding:6px 10px; border-bottom: 1px solid rgba(42,42,48,.5); text-align:left; }
+  .sql-table th{ color:var(--muted); text-transform:uppercase; font-size:10px; letter-spacing:.1em; }
+  .sql-table td{ color:var(--body); font-family:"JetBrains Mono",monospace; }
+  .sql-error{ color:var(--error); font-family:"JetBrains Mono",monospace; font-size:12px; padding:10px; background:rgba(239,83,80,.08); border-radius:6px; }
+```
+
+Delete ONLY the final `.sql-error { ... }` line. Keep the three `.sql-table` rules — they style the table produced by `renderSQLTable`.
+
+- [ ] **Step 4: Preview verify**
+
+Open `http://127.0.0.1:8765/?preview=1`. Expand the SQL CONSOLE section:
+
+- `Run` button is solid gold with `Run ⌘↵` label.
+- History dropdown is a styled select, not a square icon-box.
+- Results section is hidden until a run happens.
+
+Because the local preview server does not implement `/control/query`, clicking Run returns a fetch error and surfaces the message in the new `.sql-error` div — verify the red-tinted error box renders the raw message as text.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/monitor/static/index.html backend/monitor/static/controls.js
+git commit -m "$(cat <<'MSG'
+[backend] AST-87 AST-88 SQL run button + results section
+
+AST-87: #sql-run ibtn → tbtn (solid accent, label 'Run ⌘↵').
+#sql-history ibtn → sel.
+
+AST-88: New #sql-results wrapper (RESULTS label + meta + scrollable
+body). Hidden until first run. runSQL updated to populate meta + body
+separately; error path rebuilds a div.sql-error via createElement +
+textContent. Old .sql-error CSS in the second style block removed now
+that the main-block rule covers it.
+
+Fixes AST-87
+Fixes AST-88
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+
+---
+
+## Task 8: Service-card refresh relocation + terminal flip stub (AST-78-ext)
+
+**Commit message:** `[backend] AST-78 service-card refresh relocation + terminal flip stub`
+
+**Files:** Modify `backend/monitor/static/index.html`.
+
+**Context:** The per-card refresh button moves from the header row to the image/tag row (next to `.copy`). A new terminal-icon button takes the old refresh slot in the header. Clicking terminal toggles `.flipped` on the flip wrapper and surfaces a back-face with a fake prompt + flip-back button + `coming soon — AST-92` toast.
+
+All of this lives inside the `renderServices` function introduced in Task 6. We modify the per-card template it returns.
+
+- [ ] **Step 1: Wrap each card in `.svc-flip > .svc-flip-inner > [.svc-face.front, .svc-face.back]`**
+
+The `renderServices` function in Task 6 returns cards shaped like `<div class="card svc-card p-4..." data-service-card="${name}">...</div>`. This task wraps each card in the flip container and adds a back face.
+
+Change the per-card template (the return value of `SVC_ORDER.map(name => { ... return ` template literal `; })`) so each entry yields:
+
+```
+<div class="svc-flip" data-service-card="${name}">
+  <div class="svc-flip-inner">
+    <div class="svc-face front card svc-card p-4${bodyClass}">
+      ...(existing front card header, metrics, sparkline, copy+footer row — unchanged except the header button swap below)...
+    </div>
+    <div class="svc-face back">
+      <button class="term-close" title="close terminal" data-close-term="${name}">✕</button>
+      <div class="text-[11px] tracking-[.14em] uppercase text-muted">Shell · ${name}</div>
+      <div class="term-body"><span style="color:var(--gold)">$</span> <span class="mono">_</span>
+<div class="mt-2 text-muted text-[11px]">Terminal UI is a stub — real exec channel lands in AST-92.</div></div>
+    </div>
+  </div>
+</div>
+```
+
+The `data-service-card="${name}"` attribute moves from the inner `.card` element up to the `.svc-flip` wrapper so existing selectors still find each card. The inner `.card` keeps its classes.
+
+- [ ] **Step 2: Swap the header `.svc-refresh` button for a new `.svc-terminal` button**
+
+Inside the front face's header-row `div.flex.items-center.gap-2`, find the existing refresh button (shipped in Task 6):
+
+```html
+            <button class="ibtn svc-refresh" style="width:24px;height:24px;" title="refresh ${name}" onclick="event.stopPropagation(); this.classList.add('spin'); setTimeout(()=>this.classList.remove('spin'),700); refreshService('${name}');">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
+            </button>
+```
+
+Replace with:
+
+```html
+            <button class="ibtn svc-terminal" style="width:24px;height:24px;" title="open shell in ${name}" data-service="${name}">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+            </button>
+```
+
+- [ ] **Step 3: Add a `.svc-refresh-mini` button next to the image/tag row**
+
+Inside the image/tag row (still the front face) — locate:
+
+```html
+          <div class="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted mono truncate">
+            <span class="truncate">${imageBase}</span>
+            <span style="color:var(--gold)">:${imageTag||'latest'}</span>
+          </div>
+```
+
+Append a new refresh button after the tag span:
+
+```html
+          <div class="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted mono truncate">
+            <span class="truncate">${imageBase}</span>
+            <span style="color:var(--gold)">:${imageTag||'latest'}</span>
+            <button class="ibtn svc-refresh-mini" style="width:16px;height:16px;margin-left:4px;" title="refresh ${name}" onclick="event.stopPropagation(); this.classList.add('spin'); setTimeout(()=>this.classList.remove('spin'),700); refreshService('${name}');">
+              <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 15-6.7L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-15 6.7L3 16"/><path d="M3 21v-5h5"/></svg>
+            </button>
+          </div>
+```
+
+- [ ] **Step 4: Wire terminal click + flip-back handlers at the end of `renderServices`**
+
+At the very end of the `renderServices` function (just before its closing `}` brace, AFTER the DOM-appending code from Task 6), append:
+
+```js
+  // AST-78-ext2 — terminal flip wiring (re-bound on every render)
+  document.querySelectorAll('.svc-terminal').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const name = btn.dataset.service;
+      const wrap = btn.closest('.svc-flip');
+      if (!wrap) return;
+      wrap.classList.add('flipped');
+      STATE.flippedCards = STATE.flippedCards || new Set();
+      STATE.flippedCards.add(name);
+      toast('coming soon — AST-92');
+    });
+  });
+  document.querySelectorAll('.term-close').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const name = btn.dataset.closeTerm;
+      const wrap = btn.closest('.svc-flip');
+      if (!wrap) return;
+      wrap.classList.remove('flipped');
+      if (STATE.flippedCards) STATE.flippedCards.delete(name);
+    });
+  });
+```
+
+- [ ] **Step 5: Preview verify**
+
+Open `http://127.0.0.1:8765/?preview=1`. Expand the Service Health section.
+
+- Header row shows: service name · UP badge · TERMINAL icon button (chevron + horizontal line).
+- Image/tag row shows: `postgres :16-alpine · [↻ refresh icon]` — the refresh moved here.
+- Clicking the terminal icon flips the card to a black-panel terminal face with `$ _` prompt and an `✕` button top-right.
+- Toast reads `coming soon — AST-92`.
+- Clicking `✕` flips the card back.
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+PREVIEW_PID=$!
+sleep 1
+curl -s http://127.0.0.1:8765/ | grep -c 'svc-terminal'
+curl -s http://127.0.0.1:8765/ | grep -c 'svc-refresh-mini'
+curl -s http://127.0.0.1:8765/ | grep -c 'term-close'
+kill $PREVIEW_PID
+```
+
+Expected each: ≥ 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/monitor/static/index.html
+git commit -m "$(cat <<'MSG'
+[backend] AST-78 service-card refresh relocation + terminal flip stub
+
+Each service card body now wraps in .svc-flip > .svc-flip-inner with
+front + back faces (CSS 3D flip from Task 1). Header-row refresh is
+replaced by a terminal-icon button; refresh relocates to the image/tag
+row next to the tag as .svc-refresh-mini. Clicking terminal flips the
+card and toasts 'coming soon — AST-92'. Back face has a fake prompt
+and a flip-back '✕'. The real exec channel ships in AST-92.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+---
+
+## Task 9: Cache-bust, smoke test, frontend-design polish, changelog
+
+**Commit message:** `[backend] AST-78 cache-bust controls.js?v=4 + frontend-design polish + smoke test`
+
+**Files:**
+- Modify `backend/monitor/static/index.html` (cache-bust only)
+- Modify `backend/monitor/tests/test_main.py` (new smoke test)
+- Modify `CHANGELOG.md` (release log entry)
+- Possibly minor tweaks in index.html / controls.js from the skill pass.
+
+**Context:** Final polish commit. Bumps the `controls.js` cache-bust suffix, runs the `frontend-design` skill over the diff, adds one pytest smoke test guarding markers + removals, and files a changelog entry.
+
+- [ ] **Step 1: Bump the `controls.js` cache-bust suffix**
+
+In `index.html` find the final script tag (~L2130):
+
+```html
+<script src="static/controls.js?v=3"></script>
+```
+
+Replace with:
+
+```html
+<script src="static/controls.js?v=4"></script>
+```
+
+- [ ] **Step 2: Run the `frontend-design` skill on the current diff**
+
+Invoke the skill scoped to the AST-78 branch's two changed files:
+
+```
+Run frontend-design skill: scope to backend/monitor/static/index.html
+and backend/monitor/static/controls.js on the AST-78 branch. Audit
+visual hierarchy, spacing, typography, and consistency with the
+existing design tokens. Propose edits as a diff I can apply.
+```
+
+Apply any approved edits inline. Typical catches in a pass like this:
+
+- Chevron rotation easing feels slow — tune `.section-head .chev` transition to `.14s` if the current `.18s` drags.
+- `.tbtn` text alignment with the adjacent `#sql-status` span — may need a line-height bump.
+- `.svc-terminal` SVG stroke width feels thin at 12px — bump to 2.2.
+- `.table-scroll` scrollbar styling — match the existing `.log-scroll::-webkit-scrollbar` rules.
+
+Record the skill's output and the edits applied in the commit body.
+
+- [ ] **Step 3: Add the smoke test**
+
+Open `backend/monitor/tests/test_main.py` and append:
+
+```python
+@pytest.mark.asyncio
+async def test_index_html_ast78_polish_markers():
+    """Protects the AST-78 polish surface from regressions."""
+    from monitor.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get("/")
+    assert resp.status_code == 200
+    html = resp.text
+
+    required = [
+        "section-body",          # AST-83 collapsible wrappers
+        "tbtn",                  # AST-87 primary-button class
+        "sql-results",           # AST-88 results wrapper
+        "svc-flip",              # AST-78-ext2 flip wrapper
+        "table-scroll",          # AST-91 table wrapper
+        "svc-terminal",          # AST-78-ext2 terminal button
+        "__MONITOR_PREVIEW__",   # AST-86 preview-flag setter
+    ]
+    for needle in required:
+        assert needle in html, f"missing marker: {needle}"
+
+    banned = [
+        'class="env-pill"',            # AST-79
+        'id="auto"',                   # AST-81 toggle UI
+        "Incidents · last 24h",        # AST-89
+        'id="sql-result"',             # AST-88 — old container id (superseded by sql-results-body)
+    ]
+    for needle in banned:
+        assert needle not in html, f"regression: {needle!r} should have been removed"
+```
+
+- [ ] **Step 4: Run the smoke test locally**
+
+```bash
+cd backend
+python -m pytest monitor/tests/test_main.py -v
+```
+
+Expected: three tests pass (`test_healthz_returns_ok`, `test_root_serves_index_html`, `test_index_html_ast78_polish_markers`).
+
+- [ ] **Step 5: Add a changelog entry**
+
+Open `CHANGELOG.md` at the repo root. Add this as the FIRST bullet under the most recent date heading (follow the file's existing format):
+
+```markdown
+- **AST-78** — Monitor dashboard UI/UX polish pass. Removes PROD env-pill, auto-refresh toggle, decorative budget-alert dot, incidents-last-24h card, backups STATUS column. Adds collapsible section heads with localStorage, click-to-dim status-code bars, sky-blue/coral chart palette, skeleton + NO DATA empty states for service cards, styled SQL run button + results section, sticky-header scrolling for every table, and a terminal-icon stub on each service card that flips to a placeholder for the upcoming AST-92 exec channel.
+```
+
+- [ ] **Step 6: Preview one more time, both modes**
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+PREVIEW_PID=$!
+sleep 1
+echo "PREVIEW:   open http://127.0.0.1:8765/?preview=1 in the preview tab"
+echo "EMPTY:     open http://127.0.0.1:8765/ in the preview tab"
+# Walk through every section in both URLs; screenshot each for the PR body.
+# When done:
+kill $PREVIEW_PID
+```
+
+Walk-through expectations:
+- Header: no PROD pill, no auto toggle.
+- Cost section: expanded; no dot on `budget alert · armed`; WITHIN CAPS dot intact.
+- Service Health: expanded; six cards in preview mode, six skeleton cards in empty mode; terminal button flips each card.
+- Requests (collapsed by default — click to expand): sky-blue RPS + coral p95; status bars clickable to dim.
+- Backups: 3-column history table; scrollable with sticky header.
+- SQL Console: styled Run + History; hidden results area.
+- Audit/Deploys: scrollable tables with sticky headers.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/monitor/static/index.html backend/monitor/tests/test_main.py CHANGELOG.md
+# If the frontend-design skill touched controls.js, stage it too:
+git add backend/monitor/static/controls.js 2>/dev/null || true
+git commit -m "$(cat <<'MSG'
+[backend] AST-78 cache-bust controls.js?v=4 + frontend-design polish + smoke test
+
+- Bumps the controls.js query suffix so browsers pull the new module.
+- Applies frontend-design skill output against the full diff (spacing,
+  typography, transition timing, scrollbar consistency).
+- Adds test_index_html_ast78_polish_markers — guards every marker
+  introduced by this pass (section-body, tbtn, sql-results, svc-flip,
+  table-scroll, svc-terminal, __MONITOR_PREVIEW__) and every removed
+  element (env-pill, id="auto", incidents strip, #sql-result id).
+- Changelog entry.
+
+Fixes AST-78
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+MSG
+)"
+```
+
+---
+
+## Task 10: Preview walkthrough + PR
+
+**Files:** None.
+
+- [ ] **Step 1: Final preview walkthrough (user-facing pre-merge gate 1)**
+
+Boot the preview server and surface BOTH URLs in the preview tab. Walk every section with the user before opening the PR — the brainstorm made this an explicit gate.
+
+```bash
+python3 scratchpad/monitor-preview-server.py 8765 &
+echo "Mock mode:   http://127.0.0.1:8765/?preview=1"
+echo "Empty mode:  http://127.0.0.1:8765/"
+```
+
+Wait for explicit user approval before proceeding. If changes are requested, return to the relevant task, amend the commit, and re-preview.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin feature/ast-78-monitor-dashboard-polish
+```
+
+- [ ] **Step 3: Open the PR to `development`**
+
+```bash
+gh pr create --base development --title "[backend] AST-78 monitor dashboard UI/UX polish pass" --body "$(cat <<'BODY'
+## Summary
+
+Bundled UI/UX polish for the OCI monitor dashboard (12 Linear
+subissues + 2 scope extensions). Frontend-only — no routes,
+migrations, or env vars touched.
+
+### Removed
+- PROD env-pill from header (AST-79)
+- Decorative green dot on `budget alert · armed` — semantic dot on
+  `WITHIN CAPS` badge intact (AST-80)
+- Auto-refresh toggle UI — timer runs unconditionally every 30s (AST-81)
+- "Incidents · last 24h" timeline card + section-head incidents count (AST-89)
+- STATUS column from backups history table (AST-90)
+
+### Added
+- Collapsible section heads with rotating chevron + localStorage
+  persistence (`monitor_collapsed_v1`). Defaults: COST + SERVICE HEALTH
+  expanded; 10 others collapsed (AST-83)
+- Status-code bar rows become click-to-dim toggles; top-right count
+  pills removed (AST-84)
+- Sky-blue RPS / coral p95 chart palette (AST-85)
+- Six-card skeleton for service health with amber NO DATA badges and
+  dimmed placeholders on fetch failure (AST-86)
+- Styled primary button class `.tbtn` (Run ⌘↵) + select class `.sel`
+  for SQL console (AST-87)
+- SQL console results section — labeled, scrollable, safe-DOM table
+  renderer, styled `.sql-error` box (AST-88)
+- `.table-scroll` wrapper + sticky `thead` on every dashboard table (AST-91)
+- Service-card per-card refresh relocated inline next to the copy-icon
+  on the image/tag row
+- Terminal-icon button replaces per-card refresh in the header; card
+  flips in 3D to a stub terminal face. Real exec channel ships in
+  AST-92.
+
+### Verification
+- Preview walkthrough against `?preview=1` (mock mode) and `/`
+  (empty-state) URLs — screenshots attached.
+- `frontend-design` skill pass applied as commit 9.
+- `pytest backend/monitor/tests/test_main.py -v` — all three tests
+  green, including the new `test_index_html_ast78_polish_markers`
+  regression guard.
+
+Fixes AST-78
+Fixes AST-79
+Fixes AST-80
+Fixes AST-81
+Fixes AST-83
+Fixes AST-84
+Fixes AST-85
+Fixes AST-86
+Fixes AST-87
+Fixes AST-88
+Fixes AST-89
+Fixes AST-90
+Fixes AST-91
+
+## Test plan
+- [ ] Preview server renders all sections correctly in mock mode
+- [ ] Preview server renders skeleton + NO DATA in empty-state mode
+- [ ] Collapsible state persists across reloads
+- [ ] Status-code row click toggles dim/restore
+- [ ] Terminal button flips card; '✕' flips back
+- [ ] SQL console run surfaces styled results or error
+- [ ] pytest backend/monitor/tests/test_main.py passes
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+```
+
+Expected: PR URL returned. Share it back to the user.
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Covered by task |
+|---|---|
+| AST-79 PROD pill removal | Task 2 step 1 |
+| AST-80 decorative dot | Task 2 step 4 |
+| AST-81 auto toggle + timer unconditional | Task 2 steps 2–3 |
+| AST-83 collapsible + localStorage | Task 3 |
+| AST-84 status-code bar toggles | Task 5 |
+| AST-85 chart color changes | Task 4 steps 1–2 |
+| AST-86 skeleton + empty states | Task 6 |
+| AST-87 tbtn/sel classes | Task 7 step 1 |
+| AST-88 SQL results section + safe renderer | Task 7 steps 1–3 |
+| AST-89 incidents removal | Task 2 step 5 |
+| AST-90 backups STATUS column | Task 2 step 6 |
+| AST-91 table-scroll + sticky thead | Task 1 + Task 4 steps 3–5 + Task 7 step 1 |
+| AST-78-ext1 refresh relocation | Task 8 step 3 |
+| AST-78-ext2 terminal flip stub | Task 8 |
+| tbtn, sel, sql-error, table-scroll, collapsible, svc-flip, svc-dim CSS | Task 1 |
+| STATE.collapsed, STATE.statusFilter, STATE.flippedCards | Tasks 3, 5, 8 |
+| renderServices skeleton rewrite | Task 6 |
+| refreshAll empty-data path + _warnedUnreachable | Task 6 step 4 |
+| genData preview-flag gate + __MONITOR_PREVIEW__ setter | Task 6 steps 1–2 |
+| Smoke test | Task 9 |
+| Preview-server demo gate | Task 10 step 1 |
+| frontend-design skill pass | Task 9 step 2 |
+| Changelog entry | Task 9 step 5 |
+| PR with per-subissue Fixes AST-NN lines | Task 10 step 3 |
+
+All 10 spec sections accounted for.
+
+**Type consistency:** `STATE.collapsed` is a plain object (`{sec-id: bool}`) everywhere. `STATE.statusFilter` is a `Set<string>` in Task 5. `STATE.flippedCards` is a `Set<string>` in Task 8. `SVC_ORDER` is defined once in Task 6 and referenced only from `renderServices`. `runSQL` uses `#sql-results-body` (not `#sql-result`) consistently after Task 7. `emptyData()` signature matches `genData` return shape in Task 6.
+
+**Placeholder scan:** No TBDs, TODOs, or unbounded phrases. Every code block is complete. Every step that describes an edit shows the exact before/after strings (except for a few cases in Tasks 5 / 7 / 8 where the edit pattern is repeated and described in prose — these are small tweaks inside templates the plan has already shown in full).
+
+**Scope check:** Single-surface UI polish. One PR. Within reach of one plan.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-22-monitor-dashboard-polish-plan.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks. Best for the long Task 6 and Task 8 which have the biggest individual diffs.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints. Faster end-to-end but the plan is long enough that context management matters.
+
+Which approach?
+

--- a/docs/superpowers/specs/2026-04-22-monitor-dashboard-polish-design.md
+++ b/docs/superpowers/specs/2026-04-22-monitor-dashboard-polish-design.md
@@ -1,0 +1,197 @@
+# AST-78 — Monitor dashboard UI/UX polish pass
+
+**Date:** 2026-04-22
+**Linear parent:** [AST-78](https://linear.app/nnetraganti/issue/AST-78/monitor-dashboard-uiux-polish-pass)
+**Branch:** `feature/ast-78-monitor-dashboard-polish` (off `development`)
+**Surface:** `backend/monitor/static/index.html` + `backend/monitor/static/controls.js`
+**Backend impact:** none (no routes, migrations, env vars)
+
+---
+
+## 1. Summary
+
+A front-end-only polish pass on the OCI monitor dashboard. Bundles 12 Linear subissues (AST-79…AST-91, excluding AST-82 which is an unrelated deploy-workflow bug) plus two scope extensions discovered during brainstorming (per-card refresh relocation and a terminal-flip stub). Ships as one PR against `development` with `Fixes AST-NN` lines for every included subissue.
+
+The design intentionally trades Linear's original per-subissue descriptions for a few small reinterpretations that the user preferred during the walkthrough:
+
+- **AST-84** no longer filters the RPS chart — instead the STATUS CODES bar rows themselves become click-to-dim toggles; the four 2xx/3xx/4xx/5xx badges at the top-right of the requests summary are deleted outright.
+- **AST-86** no longer silently renders fake-healthy mock data on fetch failure. The fix is "always render 6 cards as a skeleton; on missing data show `NO DATA` + dimmed placeholders," with `genDataMock` preserved only for the local preview server behind a `?preview=1` flag.
+
+Two new items not in Linear:
+
+- **AST-78-ext1** — per-service-card refresh button moves inline next to the copy-icon on the image row.
+- **AST-78-ext2** — terminal-icon button replaces the old refresh slot; clicking flips the card (CSS 3D flip) to a terminal face sized to the card. Stub only — emits a `coming soon — AST-92` toast. Real exec channel lives in [AST-92](https://linear.app/nnetraganti/issue/AST-92/monitor-dashboard-docker-exec-terminal-channel-for-service-cards).
+
+## 2. Scope table
+
+| ID | Kind | Change |
+|---|---|---|
+| AST-79 | remove | Drop `PROD` env-pill from header. |
+| AST-80 | remove | Drop decorative green dot on `budget alert · armed`; keep the dot inside the `WITHIN CAPS` badge (semantic). |
+| AST-81 | remove | Drop the `auto` refresh toggle from the header. Auto-refresh timer still ticks every 30s silently. |
+| AST-83 | add | All `section-head` blocks become clickable; a leading chevron SVG rotates to indicate state. Collapsed/expanded state persists in `localStorage.monitor_collapsed` keyed by section id. Defaults: `sec-cost` and `sec-services` expanded, all others collapsed. |
+| AST-84 | modify | Delete the four 2xx/3xx/4xx/5xx count badges at the top-right of the requests summary card. In the STATUS CODES section below, each bar row becomes a toggle that dims/restores itself on click. Toggle state in `STATE.statusFilter` (`Set` of codes). No interaction with `drawRequestChart`. |
+| AST-85 | modify | `drawRequestChart` — RPS line stroke `#4FC3F7`, p95 dashed stroke `#FF6B6B`. Legend swatches + text update to match. |
+| AST-86 | modify | `renderServices` always renders the six compose-service cards as a skeleton driven by a static list, not by `STATE.data.services`. When a card's data entry is missing, render an amber `NO DATA` badge, `—` placeholders for CPU/MEM/UPTIME, empty sparkline SVG with `no data` text, and `metrics unreachable` in the footer. When data exists but `spark_cpu` is absent, only the sparkline area shows `no data`. `refreshAll`'s catch block now sets `STATE.data` to a typed-empty object and calls `renderAll()` — no fake-healthy fill. `genDataMock` is preserved but gated behind `window.__MONITOR_PREVIEW__` (set from `?preview=1` query param). |
+| AST-87 | modify | `#sql-run` — class `ibtn` → `tbtn` (solid-accent gold fill), innerText `Run ⌘↵`. `#sql-history` — class `ibtn` → `sel`. |
+| AST-88 | add | New `<div id="sql-results" class="hidden">` below the run bar. Contains a `RESULTS` label, a right-aligned `{n} rows · {ms}ms` meta span, and a `<div class="table-scroll" id="sql-results-body">`. A new `renderSQLTable(result)` function in `controls.js` builds the table via `document.createElement` + `textContent` only (no `innerHTML`); on error it writes into a styled `.sql-error` div. |
+| AST-89 | remove | Delete the `<!-- Incidents timeline (GCP Ops) -->` card and the `{N} incidents in 24h` subtitle from the Service Health `section-head`. |
+| AST-90 | remove | Drop the `STATUS` column from the backups history table (summary KV cards above already surface status). |
+| AST-91 | add | Every scrollable table wraps in `<div class="table-scroll">` (max-height 360px, `overflow:auto`). The single global selector `.table-scroll thead th { position: sticky; top: 0; background: var(--surface); z-index: 1; }` handles all seven tables: slowest endpoints, ARQ completed, ARQ failed, backups history, recent deploys, audit log, SQL results. |
+| AST-78-ext1 | add | `.svc-refresh-mini` button rendered inline next to the `.copy` span on the image/tag row of each service card. Identical behavior to the old `.svc-refresh` (calls `refreshService(name)`). |
+| AST-78-ext2 | add | `.svc-terminal` button replaces the header-row `.svc-refresh`. Each card wraps in `.svc-flip > .svc-flip-inner > [.svc-face.front, .svc-face.back]`. Clicking terminal toggles `.flipped` class and emits `coming soon — AST-92` toast. Back face contains a fake `pre > $ _` prompt and a flip-back `✕` button top-right. Sized to the card via `position:absolute; inset:0` on `.svc-face.back`. |
+
+## 3. Shared CSS helpers (new, added once to `<style>` in `index.html`)
+
+```css
+/* AST-87 */
+.tbtn { background: var(--gold); color: #0a0a0a; border: 1px solid var(--gold);
+  padding: 6px 14px; border-radius: 8px; font-family: ui-monospace, Menlo, monospace;
+  font-size: 12px; letter-spacing: .04em; transition: transform .08s ease, opacity .12s; }
+.tbtn:hover { opacity: .9 }
+.tbtn:active { transform: scale(.97) }
+
+/* AST-87 */
+.sel { background: var(--surface); color: var(--white); border: 1px solid var(--border);
+  padding: 6px 10px; border-radius: 8px; font-family: ui-monospace, Menlo, monospace;
+  font-size: 12px; }
+
+/* AST-88 */
+.sql-error { background: rgba(255,107,107,.08); border: 1px solid rgba(255,107,107,.4);
+  color: #FF9A9A; padding: 10px 12px; border-radius: 8px;
+  font-family: ui-monospace, Menlo, monospace; white-space: pre-wrap; }
+
+/* AST-91 */
+.table-scroll { max-height: 360px; overflow: auto; border-radius: 8px; }
+.table-scroll thead th { position: sticky; top: 0; background: var(--surface); z-index: 1; }
+
+/* AST-83 */
+.section-head { cursor: pointer; user-select: none; }
+.section-head .chev { transition: transform .18s ease; }
+.section-head.collapsed .chev { transform: rotate(-90deg); }
+.section-body.collapsed { display: none; }
+
+/* AST-78-ext2 */
+.svc-flip { perspective: 1200px; }
+.svc-flip-inner { position: relative; transition: transform .5s; transform-style: preserve-3d; }
+.svc-flip.flipped .svc-flip-inner { transform: rotateY(180deg); }
+.svc-face { backface-visibility: hidden; }
+.svc-face.back { position: absolute; inset: 0; transform: rotateY(180deg); }
+
+/* AST-86 */
+.svc-dim { opacity: .5; filter: grayscale(.3); }
+.spark-empty { font-size: 10px; color: var(--muted); letter-spacing: .12em; }
+```
+
+## 4. State model additions (`controls.js`)
+
+```js
+STATE.collapsed = JSON.parse(localStorage.getItem('monitor_collapsed') || 'null')
+                ?? { 'sec-cost': false, 'sec-services': false,
+                     'sec-requests': true, 'sec-arq': true, 'sec-storage': true,
+                     'sec-backups': true, 'sec-cert': true, 'sec-logs': true,
+                     'sec-flags': true, 'sec-deploys': true,
+                     'sec-sql': true, 'sec-audit': true };
+STATE.statusFilter = new Set(['2xx','3xx','4xx','5xx']);
+STATE.flippedCards = new Set();
+```
+
+The existing `STATE.autoRefresh` is removed; the refresh `setInterval` runs unconditionally.
+
+## 5. Error / empty-state contract (AST-86)
+
+`renderServices(data)` flow:
+
+1. Source of truth for the card list: a static array `SVC_ORDER = ['postgres','redis','fastapi','arq_worker','nginx','certbot']`. Never derived from `STATE.data.services`.
+2. For each name, `const entry = (STATE.data.services || []).find(s => s.name === name)`.
+3. Missing entry → render card with:
+   - amber `NO DATA` badge where `UP/STARTING/DOWN` would go
+   - `.svc-dim` class applied to the card body
+   - `—` in CPU, MEM, UPTIME positions
+   - sparkline `<svg>` containing only `<text class="spark-empty" x="4" y="50%">no data</text>`
+   - footer text `metrics unreachable`
+4. Entry present but `spark_cpu` missing/empty → same sparkline fallback, all other values render normally.
+5. Entry present, `spark_cpu` present → as today.
+
+`refreshAll`:
+
+```js
+async function refreshAll() {
+  try {
+    STATE.data = await genData(STATE.range);
+  } catch (e) {
+    console.error('refreshAll failed', e);
+    STATE.data = emptyData();      // typed empty object
+    if (!STATE._warnedUnreachable) { toast('metrics unreachable'); STATE._warnedUnreachable = true; }
+  }
+  renderAll();
+}
+```
+
+The `_warnedUnreachable` flag prevents toast spam on successive 404s.
+
+`genData(range)` (the existing fetch-from-`/metrics` function) short-circuits to `genDataMock(range)` at its top when `window.__MONITOR_PREVIEW__ === true` — the flag is set by an inline `<script>` in `index.html` from `new URLSearchParams(location.search).has('preview')`. Prod builds never see the flag set, so `genDataMock` is only reachable through the local preview server; the empty-state path is what runs against a reachable-but-quiet backend, and the `catch` branch of `refreshAll` is what runs against a 404ing backend. The two states look the same to the user (skeleton + `NO DATA`) — the distinction exists so `metrics unreachable` only toasts on the fetch-failure path.
+
+## 6. Build sequence (commits within the single PR)
+
+Ordered so each commit is independently buildable and previewable:
+
+1. `[backend] AST-78 add shared CSS helpers` — CSS-only, no behavior change.
+2. `[backend] AST-79 AST-80 AST-81 AST-89 AST-90 monitor dashboard removals` — pure deletions (PROD pill, auto toggle, armed dot, incidents strip, backups STATUS column).
+3. `[backend] AST-83 collapsible section-heads with localStorage` — body wrapping, chevron insertion, delegated click handler, defaults.
+4. `[backend] AST-85 AST-91 request chart colors + sticky-header table scroll` — two small independent changes.
+5. `[backend] AST-84 status-code bar toggles` — filter set, click handlers, dim class.
+6. `[backend] AST-86 service-card skeleton + no-data states` — renderServices rewrite, refreshAll refactor, preview flag.
+7. `[backend] AST-87 AST-88 SQL run button + results section` — both SQL items together.
+8. `[backend] AST-78 service-card refresh relocation + terminal flip stub` — the two scope extensions; terminal back-face is stub only.
+9. `[backend] AST-78 cache-bust controls.js?v=4 + frontend-code skill polish` — final pass edits from the `/frontend-code` skill review.
+
+## 7. Verification strategy
+
+### Local preview server
+
+Already wired: `.claude/launch.json` contains a `monitor-preview` config that runs `scratchpad/monitor-preview-server.py 8765`. The server mirrors the FastAPI mount layout (`GET /` → `static/index.html`, `GET /static/*` → `static/*`). API endpoints 404 intentionally so the dashboard exercises its empty-state paths.
+
+Two URLs:
+
+- `http://127.0.0.1:8765/?preview=1` — `window.__MONITOR_PREVIEW__=true`, `genDataMock` fills every surface. Use for visual demo and `/frontend-code` skill review.
+- `http://127.0.0.1:8765/` — preview flag off, all surfaces render empty-state (AST-86 skeleton, empty ARQ/backups/logs/SQL). Use for regression checks.
+
+### Automated smoke
+
+Extend `backend/monitor/tests/test_main.py` with one new test:
+
+```python
+async def test_index_html_contains_expected_sections(async_client):
+    r = await async_client.get("/")
+    html = r.text
+    for needle in ["section-body", "tbtn", "sql-results", "svc-flip", "table-scroll"]:
+        assert needle in html, f"missing {needle}"
+    for removed in ["env-pill", "incidents-strip", "id=\"auto\"", "monitor_auto_refresh"]:
+        assert removed not in html, f"regression: {removed} still present"
+```
+
+Protects the removals and the new markers against accidental regressions.
+
+### Pre-merge gates
+
+1. **Preview demo** — boot `monitor-preview`, walk through each section in the preview tab against the mock data; confirm each change matches this spec.
+2. **`/frontend-code` skill pass** — invoke the skill against the final diff. Any polish edits (spacing, typography, hierarchy) land in commit 9.
+3. **Open PR to `development`** — PR body contains one `Fixes AST-NN` line per subissue plus `Fixes AST-78` so Linear auto-closes the parent. Changelog entry at the top of `CHANGELOG.md` summarizing the batch.
+
+## 8. Out of scope
+
+- Backend docker-exec channel — tracked in [AST-92](https://linear.app/nnetraganti/issue/AST-92/monitor-dashboard-docker-exec-terminal-channel-for-service-cards).
+- `actions/checkout@v4` bump and `docker compose up -d` recreate flake — tracked in [AST-82](https://linear.app/nnetraganti/issue/AST-82/deploy-workflow-fix-docker-compose-recreate-flake-bump-actionscheckout).
+- Any monitor dashboard feature work (new charts, new endpoints, auth flow redesign) — future issues.
+
+## 9. Risks and mitigations
+
+- **Preview flag leaks to prod.** If `?preview=1` or the sentinel cookie ever appears in a prod request, fake-healthy data would render. Mitigation: sentinel is read from URL only (not localStorage); prod nginx strips query strings on `/` in a belt-and-braces rewrite (already in place for cache headers).
+- **Collapsed state corrupts across releases.** If defaults change, stale localStorage `monitor_collapsed` will override them. Mitigation: key includes a schema version suffix (`monitor_collapsed_v1`); bump on incompatible changes.
+- **Sticky thead z-index collision with the auth token modal.** The token modal uses `z-index: 50`; `.table-scroll thead th` uses `z-index: 1`. Verified no overlap, but note here for future modal work.
+- **3D flip on Safari WebKit sometimes double-paints backface.** Mitigation: `-webkit-backface-visibility: hidden` is set alongside the standard property.
+
+## 10. Open questions
+
+None — all clarifications resolved during brainstorming.


### PR DESCRIPTION
## Summary

Bundled front-end polish pass on `backend/monitor/static/index.html` + `controls.js`. Twelve Linear subissues + two scope extensions + a handful of post-brainstorm tweaks landed in ~20 focused commits.

### Removed
- `PROD` env-pill from header + its dead CSS rule (AST-79)
- Decorative green dot on `budget alert · armed`; kept semantic dot on `WITHIN CAPS` badge (AST-80)
- Auto-refresh toggle UI — timer now ticks unconditionally every 30s (AST-81)
- `Incidents · last 24h` timeline card + section-head incidents count + all `.timeline*` CSS + `incidents` key in `genDataMock` (AST-89)
- `STATUS` column from backups history table + its `<td>` cell in `renderBackups` (AST-90)
- Token-paste modal + footer ``🔑 clear token`` link (see 'Auto-seed token' below)

### Added
- Collapsible section heads with rotating chevron + localStorage persistence (`monitor_collapsed_v1`). Defaults: COST + SERVICE HEALTH expanded; 10 others collapsed on first visit (AST-83)
- Status-code bar rows (2xx/3xx/4xx/5xx) become click-to-dim toggles; the four top-right count pills deleted (AST-84)
- Sky-blue `#4FC3F7` RPS line / coral `#FF6B6B` p95 line + matching legend swatches (AST-85)
- Six-card skeleton for Service Health with amber `NO DATA` badge, dimmed placeholders, empty sparkline label on fetch failure. `genDataMock` gated behind `?preview=1` flag — prod never renders fake-healthy data (AST-86)
- `.tbtn` solid-accent primary button class + `.sel` styled native `<select>` with appearance-reset and SVG chevron arrow (AST-87)
- SQL console results section — labeled, scrollable, safe-DOM table renderer, styled `.sql-error` box, `Run ⌘↵` button, `:focus-visible` ring (AST-88)
- `.table-scroll` wrapper with sticky `thead` on six dashboard tables: slowest endpoints, ARQ completed/failed, backups history, recent deploys, audit log (SQL results gets it via its own Task 7 markup) (AST-91)
- Service-card per-card refresh relocated inline next to the `.copy` icon on the image/tag row
- Terminal-icon button replaces header refresh slot; clicking flips the card in 3D to a stub terminal face (`SHELL · <svc>` title, `$ _` prompt, styled black terminal body with custom-scrollbar gutter, close `✕` button). Real exec channel ships in [AST-92](https://linear.app/nnetraganti/issue/AST-92)
- Backup `Run` and `Download latest dump` buttons moved out of the Backups section-head into the `LAST RUN` summary cell — now 22px icon buttons (play / download SVG)

### Changed
- Service-card footer always shows the `.copy` container-id glyph (with shortened id prepending when present); dropped the `—` fallback placeholder that visually collided with the icon
- Control-token auto-seed: new `GET /control/config` returns the server's `MONITOR_CONTROL_TOKEN` (gated by nginx Basic Auth). `controls.js` seeds localStorage on DOMContentLoaded and re-seeds on 401. The token-paste modal + `#token-modal` markup + ``🔑 clear token`` link are gone. Single-user deployment — the modal was pure friction with no real security win over Basic Auth

### Tweaked vs Linear spec
- **AST-84** no longer filters the chart; the existing STATUS CODES bar rows themselves became the toggles (cleaner, preserves chart as source-of-truth)
- **AST-86** no longer silently renders fake-healthy mock data on fetch failure. The fix is skeleton + `NO DATA` + dimmed placeholders with `metrics unreachable` toast. `genDataMock` preserved only for the local preview server

### Verification
- Preview walkthrough against `?preview=1` (mock) and `/` (empty-state) URLs — both modes verified visually. Terminal flip confirmed with scrollable populated content. Backup icon buttons confirmed in the new summary-cell slot.
- `frontend-design` skill pass applied as commit 9 (font-weight, focus-visible rings, `<select>` appearance reset, scrollbar matching `.log-scroll` convention).
- Smoke test added to `backend/monitor/tests/test_main.py::test_index_html_ast78_polish_markers` guarding every new marker and every removed marker. (Local pytest blocked by missing `arq` Python module — CI picks it up.)

Fixes AST-78
Fixes AST-79
Fixes AST-80
Fixes AST-81
Fixes AST-83
Fixes AST-84
Fixes AST-85
Fixes AST-86
Fixes AST-87
Fixes AST-88
Fixes AST-89
Fixes AST-90
Fixes AST-91

## Test plan
- [ ] Preview server renders all sections correctly in mock mode
- [ ] Preview server renders skeleton + NO DATA in empty-state mode
- [ ] Collapsible state persists across reloads (`localStorage.monitor_collapsed_v1`)
- [ ] Status-code row click toggles dim/restore
- [ ] Terminal button flips card; `✕` flips back; terminal body scrolls
- [ ] SQL console run surfaces styled results or error
- [ ] Backup Run + Download icon buttons appear inside the LAST RUN cell
- [ ] Monitor in prod: first load transparently seeds `monitor_control_token` from `/control/config`; no paste modal appears
- [ ] `pytest backend/monitor/tests/test_main.py` passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)