### PR TITLE
[backend] fix postgres env wiring — broken indirection chain

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,14 +1,22 @@
 services:
   postgres:
     image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: ${POSTGRES_DB}
+    # env_file delivers POSTGRES_USER/PASSWORD/DB into the container at
+    # runtime. The previous `environment: POSTGRES_USER: ${POSTGRES_USER}`
+    # pattern relied on compose's parse-time substitution from a top-level
+    # .env file — which doesn't exist on prod (only .env.oci does, and
+    # env_file is NOT consulted for ${...} substitution in the compose
+    # file itself). That resolved every var to "" and made the healthcheck
+    # `pg_isready -U ''` fail with exit 3 → postgres stuck "unhealthy" →
+    # astral_monitor blocked behind `depends_on: service_healthy`.
+    env_file:
+      - .env.oci
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      # pg_isready only checks socket acceptance, doesn't authenticate,
+      # so no -U needed — keeps the healthcheck independent of env vars.
+      test: ["CMD-SHELL", "pg_isready -q"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Why

The postgres service was the only one using compose's parse-time \`\${VAR}\` indirection instead of \`env_file: .env.oci\`. Compose only reads a literal \`.env\` file for \`\${VAR}\` substitution — \`env_file:\` is for runtime delivery into the container, NOT for the compose file's own variable pool.

Prod has no \`.env\` file (only \`.env.example\`, \`.env.local\`, \`.env.oci\`), so every \`\${POSTGRES_USER}\` / \`\${POSTGRES_PASSWORD}\` / \`\${POSTGRES_DB}\` resolved to an empty string. Postgres still started because the data dir was already initialized and it skips re-init — but the healthcheck \`pg_isready -U ''\` exited 3. Postgres stayed permanently \"unhealthy\", and anything with \`depends_on: postgres service_healthy\` (astral_monitor, fastapi, arq_worker) couldn't start on the next deploy.

fastapi, arq_worker, and astral_monitor already use \`env_file: .env.oci\` correctly. This PR makes postgres match.

## What

- postgres gains \`env_file: .env.oci\`, dropping the broken \`environment: ${...}\` block. The postgres image natively picks up POSTGRES_USER/PASSWORD/DB from the env_file.
- Healthcheck simplified from \`pg_isready -U \${POSTGRES_USER}\` to \`pg_isready -q\`. pg_isready only checks socket acceptance, doesn't authenticate — there's no reason to thread the user through, and removing it eliminates the env dependency entirely.

## Test plan

- [x] \`docker compose config --services\` parses the new YAML cleanly
- [ ] Post-merge on prod: \`docker compose up -d postgres astral_monitor\` — postgres reports \"healthy\" within ~10s, astral_monitor starts without manual \`--no-deps\`

## Deploy note

After this merges, prod needs:
\`\`\`
cd /home/ubuntu/astral && git pull && cd backend
docker compose up -d postgres astral_monitor
\`\`\`
(Postgres will recreate to pick up the new healthcheck; ~2 s downtime.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)